### PR TITLE
Fix month analytics to include all paginated transactions and improve categories mobile layout

### DIFF
--- a/views/month/index.php
+++ b/views/month/index.php
@@ -444,7 +444,7 @@
   <div class="card h-80 overflow-hidden">
     <h3 class="font-semibold mb-3"><?= __('Top Spending Categories (:currency)', ['currency' => htmlspecialchars($main)]) ?></h3>
     <?php
-      // Build grouped sums from $allTx in MAIN (spending only)
+      // Build grouped sums from all transactions in MAIN (spending only)
       $grp = []; $cols = [];
       foreach (($allTx ?? []) as $r) {
         if (($r['kind'] ?? '') !== 'spending') continue;
@@ -646,7 +646,7 @@
 
   <!-- Mobile: stacked cards -->
   <div class="md:hidden space-y-3">
-    <?php foreach ($allTx as $row): ?>
+    <?php foreach ($txDisplay as $row): ?>
       <?php
         $isVirtual = !empty($row['is_virtual']);
         $nativeCur = $row['currency'] ?: $main;
@@ -825,7 +825,7 @@
         </tr>
       </thead>
       <tbody>
-        <?php foreach ($allTx as $row): ?>
+        <?php foreach ($txDisplay as $row): ?>
           <?php
             $isVirtual = !empty($row['is_virtual']);
             $isEF      = isset($row['source']) && $row['source'] === 'ef';

--- a/views/settings/categories.php
+++ b/views/settings/categories.php
@@ -67,10 +67,12 @@
               ?>
                 <li class="glass-stack__item">
                   <details class="group">
-                    <summary class="flex cursor-pointer items-center justify-between gap-3">
-                      <div class="flex items-center gap-2">
+                    <summary class="flex cursor-pointer flex-wrap gap-3 sm:flex-nowrap sm:items-center sm:justify-between">
+                      <div class="flex min-w-0 flex-1 flex-wrap items-center gap-2 sm:flex-nowrap">
                         <span class="inline-block h-3 w-3 rounded-full" style="background: <?= htmlspecialchars($c['color'] ?? '#6B7280') ?>;"></span>
-                        <span class="font-medium"><?= htmlspecialchars($c['label']) ?></span>
+                        <span class="font-medium break-words leading-snug">
+                          <?= htmlspecialchars($c['label']) ?>
+                        </span>
                         <?php if ($isEF): ?>
                           <span class="chip"><?= __('Protected') ?></span>
                         <?php endif; ?>
@@ -80,7 +82,7 @@
                           <span class="chip" title="<?= __('No cashflow rule set') ?>">⚠️ <?= __('No rule') ?></span>
                         <?php endif; ?>
                       </div>
-                      <span class="flex items-center gap-2 text-sm text-gray-500">
+                      <span class="flex flex-shrink-0 items-center gap-2 text-sm text-gray-500">
                         <span class="icon-action icon-action--primary" aria-hidden="true">
                           <i data-lucide="pencil" class="h-4 w-4"></i>
                         </span>


### PR DESCRIPTION
## Summary
- keep a paginated transaction list for the table while also building a full-month collection for analytics
- feed the full dataset into cashflow guidance and charts so pagination no longer trims their totals
- update the month view to render tables from the paginated list and rely on the full list for summaries
- let category summaries wrap chips and labels so the settings page remains usable on narrow screens

## Testing
- php -l Finance-tracker/src/controllers/month.php
- php -l Finance-tracker/views/month/index.php
- php -l Finance-tracker/views/settings/categories.php

------
https://chatgpt.com/codex/tasks/task_e_68d3d9b5106883299f03169b816debd5