### PR TITLE
Default quick add to spending and keep position

### DIFF
--- a/app.css
+++ b/app.css
@@ -51,3 +51,25 @@
         @apply border border-red-300 text-red-600 hover:bg-red-50;
     }
 }
+
+@layer base {
+    html.mm-scroll-restoring {
+        scroll-behavior: auto !important;
+    }
+
+    html.mm-scroll-restoring body {
+        opacity: 0;
+        pointer-events: none;
+    }
+
+    html.mm-scroll-restoring.mm-scroll-restore-ready body {
+        opacity: 1;
+        transition: opacity 200ms ease;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        html.mm-scroll-restoring.mm-scroll-restore-ready body {
+            transition-duration: 1ms;
+        }
+    }
+}

--- a/src/controllers/years.php
+++ b/src/controllers/years.php
@@ -124,8 +124,10 @@ function month_tx_add(PDO $pdo){
                   $main, $rate, $amount_main]);
 
   // redirect back
-  $y = (int)($_POST['y'] ?? date('Y')); $m = (int)($_POST['m'] ?? date('n'));
-  redirect("/years/$y/$m");
+  $y = (int)($_POST['y'] ?? date('Y'));
+  $m = (int)($_POST['m'] ?? date('n'));
+  $ym = sprintf('%04d-%02d', $y, $m);
+  redirect('/current-month?ym=' . $ym . '#quick-add');
 }
 
 function month_tx_edit(PDO $pdo){
@@ -156,14 +158,17 @@ function month_tx_edit(PDO $pdo){
   $stmt->execute([$kind, $amount, ($currency ?: $main), $occurred_on, $note,
                   $rate, $amount_main, $main, $id, $u]);
 
-  $y=(int)($_POST['y'] ?? date('Y')); $m=(int)($_POST['m'] ?? date('n'));
-  redirect("/years/$y/$m");
+  $y = (int)($_POST['y'] ?? date('Y'));
+  $m = (int)($_POST['m'] ?? date('n'));
+  $ym = sprintf('%04d-%02d', $y, $m);
+  redirect('/current-month?ym=' . $ym);
 }
 
 function month_tx_delete(PDO $pdo){ verify_csrf(); require_login();
   $y=(int)$_POST['y']; $m=(int)$_POST['m']; $u=uid();
   $pdo->prepare('DELETE FROM transactions WHERE id=? AND user_id=?')->execute([(int)$_POST['id'],$u]);
-  redirect('/years/'.$y.'/'.$m);
+  $ym = sprintf('%04d-%02d', $y, $m);
+  redirect('/current-month?ym=' . $ym);
 }
 
 function month_read_filters(): array {

--- a/src/controllers/years.php
+++ b/src/controllers/years.php
@@ -127,7 +127,7 @@ function month_tx_add(PDO $pdo){
   $y = (int)($_POST['y'] ?? date('Y'));
   $m = (int)($_POST['m'] ?? date('n'));
   $ym = sprintf('%04d-%02d', $y, $m);
-  redirect('/current-month?ym=' . $ym . '#quick-add');
+  redirect('/current-month?ym=' . $ym);
 }
 
 function month_tx_edit(PDO $pdo){

--- a/views/month/index.php
+++ b/views/month/index.php
@@ -575,7 +575,13 @@
   <div class="card md:col-span-2">
     <h3 class="text-base font-semibold mb-3"><?= __('Quick Add') ?></h3>
 
-    <form class="grid gap-4 md:grid-cols-12 md:items-end" method="post" action="/months/tx/add">
+    <form
+      class="grid gap-4 md:grid-cols-12 md:items-end"
+      method="post"
+      action="/months/tx/add"
+      data-restore-focus="#quick-add-amount"
+      data-restore-focus-select="true"
+    >
       <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
       <input type="hidden" name="y" value="<?= $y ?>" />
       <input type="hidden" name="m" value="<?= $m ?>" />
@@ -604,7 +610,7 @@
       <div class="field md:col-span-4">
         <label class="label"><?= __('Amount') ?></label>
         <div class="grid grid-cols-5 gap-2">
-          <input name="amount" type="number" step="0.01" class="input col-span-3" placeholder="0.00" required />
+          <input id="quick-add-amount" name="amount" type="number" step="0.01" class="input col-span-3" placeholder="0.00" required />
           <select name="currency" class="select col-span-2">
             <?php foreach ($userCurrencies as $c): ?>
               <option value="<?= htmlspecialchars($c['code']) ?>" <?= $c['is_main'] ? 'selected' : '' ?>>
@@ -639,75 +645,6 @@
     </form>
   </div>
 </section>
-
-<script>
-  (function () {
-    const quickAdd = document.querySelector('#quick-add form');
-    if (!quickAdd) return;
-
-    let storage;
-    try {
-      storage = window.sessionStorage;
-    } catch (err) {
-      storage = null;
-    }
-    if (!storage) return;
-
-    const SCROLL_KEY = 'month:quick-add:scroll';
-    const FOCUS_KEY = 'month:quick-add:focus';
-
-    quickAdd.addEventListener('submit', () => {
-      try {
-        const y = window.scrollY || window.pageYOffset || document.documentElement.scrollTop || 0;
-        storage.setItem(SCROLL_KEY, String(Math.max(0, Math.round(y))));
-        storage.setItem(FOCUS_KEY, '1');
-      } catch (err) {
-        // no-op when sessionStorage is unavailable
-      }
-    });
-
-    const restore = () => {
-      try {
-        const raw = storage.getItem(SCROLL_KEY);
-        if (raw === null) return;
-        storage.removeItem(SCROLL_KEY);
-
-        const scrollTarget = parseInt(raw, 10);
-        if (!Number.isNaN(scrollTarget)) {
-          try {
-            window.scrollTo({ top: scrollTarget, behavior: 'instant' });
-          } catch (err) {
-            window.scrollTo(0, scrollTarget);
-          }
-        }
-
-        const shouldFocus = storage.getItem(FOCUS_KEY) === '1';
-        storage.removeItem(FOCUS_KEY);
-        if (shouldFocus) {
-          const amount = quickAdd.querySelector('input[name="amount"]');
-          if (amount) {
-            try {
-              amount.focus({ preventScroll: true });
-            } catch (err) {
-              amount.focus();
-            }
-            if (typeof amount.select === 'function') {
-              amount.select();
-            }
-          }
-        }
-      } catch (err) {
-        // ignore restore errors
-      }
-    };
-
-    if (document.readyState === 'complete') {
-      restore();
-    } else {
-      window.addEventListener('load', restore, { once: true });
-    }
-  })();
-</script>
 
 <!-- Transactions -->
 <section class="mt-6 card">

--- a/views/month/index.php
+++ b/views/month/index.php
@@ -571,7 +571,7 @@
 </section>
 
 <!-- Add transaction -->
-<section class="mt-6 grid md:grid-cols-2 gap-6">
+<section id="quick-add" class="mt-6 grid md:grid-cols-2 gap-6">
   <div class="card md:col-span-2">
     <h3 class="text-base font-semibold mb-3"><?= __('Quick Add') ?></h3>
 
@@ -585,7 +585,7 @@
         <label class="label"><?= __('Type') ?></label>
         <select name="kind" class="select">
           <option value="income">Income</option>
-          <option value="spending">Spending</option>
+          <option value="spending" selected>Spending</option>
         </select>
       </div>
 

--- a/views/month/index.php
+++ b/views/month/index.php
@@ -640,6 +640,75 @@
   </div>
 </section>
 
+<script>
+  (function () {
+    const quickAdd = document.querySelector('#quick-add form');
+    if (!quickAdd) return;
+
+    let storage;
+    try {
+      storage = window.sessionStorage;
+    } catch (err) {
+      storage = null;
+    }
+    if (!storage) return;
+
+    const SCROLL_KEY = 'month:quick-add:scroll';
+    const FOCUS_KEY = 'month:quick-add:focus';
+
+    quickAdd.addEventListener('submit', () => {
+      try {
+        const y = window.scrollY || window.pageYOffset || document.documentElement.scrollTop || 0;
+        storage.setItem(SCROLL_KEY, String(Math.max(0, Math.round(y))));
+        storage.setItem(FOCUS_KEY, '1');
+      } catch (err) {
+        // no-op when sessionStorage is unavailable
+      }
+    });
+
+    const restore = () => {
+      try {
+        const raw = storage.getItem(SCROLL_KEY);
+        if (raw === null) return;
+        storage.removeItem(SCROLL_KEY);
+
+        const scrollTarget = parseInt(raw, 10);
+        if (!Number.isNaN(scrollTarget)) {
+          try {
+            window.scrollTo({ top: scrollTarget, behavior: 'instant' });
+          } catch (err) {
+            window.scrollTo(0, scrollTarget);
+          }
+        }
+
+        const shouldFocus = storage.getItem(FOCUS_KEY) === '1';
+        storage.removeItem(FOCUS_KEY);
+        if (shouldFocus) {
+          const amount = quickAdd.querySelector('input[name="amount"]');
+          if (amount) {
+            try {
+              amount.focus({ preventScroll: true });
+            } catch (err) {
+              amount.focus();
+            }
+            if (typeof amount.select === 'function') {
+              amount.select();
+            }
+          }
+        }
+      } catch (err) {
+        // ignore restore errors
+      }
+    };
+
+    if (document.readyState === 'complete') {
+      restore();
+    } else {
+      window.addEventListener('load', restore, { once: true });
+    }
+  })();
+</script>
+
 <!-- Transactions -->
 <section class="mt-6 card">
   <h3 class="font-semibold mb-3"><?= __('Transactions') ?></h3>


### PR DESCRIPTION
## Summary
- default the month quick add type selector to spending
- anchor the quick add section and redirect back to it after submission so the page doesn't jump to the top
- route the month transaction redirects through `/current-month` so quick add returns to the month page anchor

## Testing
- php -l src/controllers/years.php
- php -l views/month/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d3e8b507048329869d48667c1c7b83