### PR TITLE
Improve mobile experience and dialogs

### DIFF
--- a/index.php
+++ b/index.php
@@ -530,6 +530,12 @@ switch ($path) {
         feedback_index($pdo);
         break;
 
+    case '/more':
+        require_login();
+        require __DIR__ . '/src/controllers/more.php';
+        more_show($pdo);
+        break;
+
     case '/feedback/add':
         require_login();
         require __DIR__ . '/src/controllers/feedback.php';

--- a/lang/es.php
+++ b/lang/es.php
@@ -361,6 +361,8 @@ return [
     'left' => 'restante',
     'over' => 'excedido',
     'Manage Currencies' => 'Administrar monedas',
+    'Back to Settings' => 'Volver a Configuración',
+    'Back to More' => 'Volver a Más',
     '← Back to Settings' => '← Volver a Configuración',
     'Your currencies' => 'Tus monedas',
     'Set main' => 'Establecer principal',

--- a/lang/es.php
+++ b/lang/es.php
@@ -67,6 +67,7 @@ return [
     'Balance: :amount' => 'Saldo: :amount',
     'Amount' => 'Monto',
     'Dashboard' => 'Panel',
+    'Current month' => 'Mes actual',
     'Emergency' => 'Emergencia',
     'Scheduled' => 'Programado',
     'Feedback' => 'Comentarios',

--- a/lang/hu.php
+++ b/lang/hu.php
@@ -363,6 +363,8 @@ return [
     'left' => 'maradt',
     'over' => 'túllépve',
     'Manage Currencies' => 'Pénznemek kezelése',
+    'Back to Settings' => 'Vissza a beállításokhoz',
+    'Back to More' => 'Vissza a Továbbiakhoz',
     '← Back to Settings' => '← Vissza a beállításokhoz',
     'Your currencies' => 'Pénznemeid',
     'Set main' => 'Legyen fő pénznem',

--- a/lang/hu.php
+++ b/lang/hu.php
@@ -69,6 +69,7 @@ return [
     'Language' => 'Nyelv',
     'Welcome back' => 'Üdv újra',
     'Dashboard' => 'Vezérlőpult',
+    'Current month' => 'Aktuális hónap',
     'Emergency' => 'Vészalap',
     'Scheduled' => 'Ütemezett',
     'Feedback' => 'Visszajelzés',

--- a/src/controllers/more.php
+++ b/src/controllers/more.php
@@ -90,12 +90,6 @@ function more_show(PDO $pdo): void
                     'href' => '/settings/categories',
                     'icon' => 'tags',
                 ],
-                [
-                    'label' => __('Language'),
-                    'description' => __('Switch the interface to your preferred language.'),
-                    'href' => '/settings#language',
-                    'icon' => 'languages',
-                ],
             ],
         ],
         [
@@ -117,9 +111,20 @@ function more_show(PDO $pdo): void
         ],
     ];
 
+    $localeOptions = available_locales();
+    $currentLocale = app_locale();
+    $localeFlags = [
+        'en' => '🇺🇸',
+        'hu' => '🇭🇺',
+        'es' => '🇪🇸',
+    ];
+
     view('more/index', [
         'user' => $user,
         'displayName' => $displayName,
         'navSections' => $navSections,
+        'localeOptions' => $localeOptions,
+        'currentLocale' => $currentLocale,
+        'localeFlags' => $localeFlags,
     ]);
 }

--- a/src/controllers/more.php
+++ b/src/controllers/more.php
@@ -12,8 +12,14 @@ function more_show(PDO $pdo): void
 
     $navSections = [
         [
-            'title' => __('Money & budgeting'),
+            'title' => __('Overview & money'),
             'items' => [
+                [
+                    'label' => __('Dashboard'),
+                    'description' => __('Snapshot of balances, trends, and recent activity.'),
+                    'href' => '/',
+                    'icon' => 'layout-dashboard',
+                ],
                 [
                     'label' => __('Current month'),
                     'description' => __('Review this month\'s spending, income, and budgets.'),
@@ -25,18 +31,6 @@ function more_show(PDO $pdo): void
                     'description' => __('Track upcoming bills and automatic payments.'),
                     'href' => '/scheduled',
                     'icon' => 'calendar-clock',
-                ],
-                [
-                    'label' => __('Basic incomes'),
-                    'description' => __('Manage recurring income sources and salary updates.'),
-                    'href' => '/settings/basic-incomes',
-                    'icon' => 'coins',
-                ],
-                [
-                    'label' => __('Cashflow rules'),
-                    'description' => __('Adjust envelope allocations and automation preferences.'),
-                    'href' => '/settings/cashflow',
-                    'icon' => 'sliders-horizontal',
                 ],
             ],
         ],
@@ -59,36 +53,7 @@ function more_show(PDO $pdo): void
                     'label' => __('Emergency fund'),
                     'description' => __('Grow and protect your safety net for surprises.'),
                     'href' => '/emergency',
-                    'icon' => 'lifebuoy',
-                ],
-            ],
-        ],
-        [
-            'title' => __('Insights & reports'),
-            'items' => [
-                [
-                    'label' => __('Dashboard'),
-                    'description' => __('Snapshot of balances, trends, and recent activity.'),
-                    'href' => '/',
-                    'icon' => 'layout-dashboard',
-                ],
-                [
-                    'label' => __('Months & years'),
-                    'description' => __('Browse historical months and yearly summaries.'),
-                    'href' => '/years',
-                    'icon' => 'calendar-range',
-                ],
-                [
-                    'label' => __('Stocks'),
-                    'description' => __('Track portfolio performance and trades.'),
-                    'href' => '/stocks',
-                    'icon' => 'line-chart',
-                ],
-                [
-                    'label' => __('Feedback'),
-                    'description' => __('Share product ideas or report an issue.'),
-                    'href' => '/feedback',
-                    'icon' => 'message-circle',
+                    'icon' => 'life-buoy',
                 ],
             ],
         ],
@@ -96,22 +61,22 @@ function more_show(PDO $pdo): void
             'title' => __('Settings & personalisation'),
             'items' => [
                 [
-                    'label' => __('Settings overview'),
-                    'description' => __('Review currencies, incomes, and automation shortcuts.'),
-                    'href' => '/settings',
-                    'icon' => 'settings',
-                ],
-                [
-                    'label' => __('Profile settings'),
-                    'description' => __('Update your personal details and contact info.'),
-                    'href' => '/settings/profile',
-                    'icon' => 'user-cog',
-                ],
-                [
                     'label' => __('Theme & appearance'),
                     'description' => __('Fine-tune colours, typography, and look & feel.'),
                     'href' => '/settings/theme',
                     'icon' => 'palette',
+                ],
+                [
+                    'label' => __('Basic incomes'),
+                    'description' => __('Manage recurring income sources and salary updates.'),
+                    'href' => '/settings/basic-incomes',
+                    'icon' => 'coins',
+                ],
+                [
+                    'label' => __('Cashflow rules'),
+                    'description' => __('Adjust envelope allocations and automation preferences.'),
+                    'href' => '/settings/cashflow',
+                    'icon' => 'sliders-horizontal',
                 ],
                 [
                     'label' => __('Currencies'),
@@ -124,6 +89,29 @@ function more_show(PDO $pdo): void
                     'description' => __('Organise income and spending categories.'),
                     'href' => '/settings/categories',
                     'icon' => 'tags',
+                ],
+                [
+                    'label' => __('Language'),
+                    'description' => __('Switch the interface to your preferred language.'),
+                    'href' => '/settings#language',
+                    'icon' => 'languages',
+                ],
+            ],
+        ],
+        [
+            'title' => __('Help & feedback'),
+            'items' => [
+                [
+                    'label' => __('Tutorial'),
+                    'description' => __('Learn the ropes of goals, loans, and budgeting.'),
+                    'href' => '/tutorial',
+                    'icon' => 'graduation-cap',
+                ],
+                [
+                    'label' => __('Feedback'),
+                    'description' => __('Share product ideas or report an issue.'),
+                    'href' => '/feedback',
+                    'icon' => 'message-circle',
                 ],
             ],
         ],

--- a/src/controllers/more.php
+++ b/src/controllers/more.php
@@ -1,0 +1,137 @@
+<?php
+
+function more_show(PDO $pdo): void
+{
+    $userId = uid();
+
+    $stmt = $pdo->prepare('SELECT full_name, email FROM users WHERE id = ? LIMIT 1');
+    $stmt->execute([$userId]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC) ?: ['full_name' => '', 'email' => ''];
+
+    $displayName = trim($user['full_name'] ?? '') ?: ($user['email'] ?? '');
+
+    $navSections = [
+        [
+            'title' => __('Money & budgeting'),
+            'items' => [
+                [
+                    'label' => __('Current month'),
+                    'description' => __('Review this month\'s spending, income, and budgets.'),
+                    'href' => '/current-month',
+                    'icon' => 'calendar-check',
+                ],
+                [
+                    'label' => __('Scheduled payments'),
+                    'description' => __('Track upcoming bills and automatic payments.'),
+                    'href' => '/scheduled',
+                    'icon' => 'calendar-clock',
+                ],
+                [
+                    'label' => __('Basic incomes'),
+                    'description' => __('Manage recurring income sources and salary updates.'),
+                    'href' => '/settings/basic-incomes',
+                    'icon' => 'coins',
+                ],
+                [
+                    'label' => __('Cashflow rules'),
+                    'description' => __('Adjust envelope allocations and automation preferences.'),
+                    'href' => '/settings/cashflow',
+                    'icon' => 'sliders-horizontal',
+                ],
+            ],
+        ],
+        [
+            'title' => __('Planning & goals'),
+            'items' => [
+                [
+                    'label' => __('Goals'),
+                    'description' => __('Set, fund, and celebrate your savings goals.'),
+                    'href' => '/goals',
+                    'icon' => 'goal',
+                ],
+                [
+                    'label' => __('Loans'),
+                    'description' => __('Manage debts, schedules, and payoff progress.'),
+                    'href' => '/loans',
+                    'icon' => 'landmark',
+                ],
+                [
+                    'label' => __('Emergency fund'),
+                    'description' => __('Grow and protect your safety net for surprises.'),
+                    'href' => '/emergency',
+                    'icon' => 'lifebuoy',
+                ],
+            ],
+        ],
+        [
+            'title' => __('Insights & reports'),
+            'items' => [
+                [
+                    'label' => __('Dashboard'),
+                    'description' => __('Snapshot of balances, trends, and recent activity.'),
+                    'href' => '/',
+                    'icon' => 'layout-dashboard',
+                ],
+                [
+                    'label' => __('Months & years'),
+                    'description' => __('Browse historical months and yearly summaries.'),
+                    'href' => '/years',
+                    'icon' => 'calendar-range',
+                ],
+                [
+                    'label' => __('Stocks'),
+                    'description' => __('Track portfolio performance and trades.'),
+                    'href' => '/stocks',
+                    'icon' => 'line-chart',
+                ],
+                [
+                    'label' => __('Feedback'),
+                    'description' => __('Share product ideas or report an issue.'),
+                    'href' => '/feedback',
+                    'icon' => 'message-circle',
+                ],
+            ],
+        ],
+        [
+            'title' => __('Settings & personalisation'),
+            'items' => [
+                [
+                    'label' => __('Settings overview'),
+                    'description' => __('Review currencies, incomes, and automation shortcuts.'),
+                    'href' => '/settings',
+                    'icon' => 'settings',
+                ],
+                [
+                    'label' => __('Profile settings'),
+                    'description' => __('Update your personal details and contact info.'),
+                    'href' => '/settings/profile',
+                    'icon' => 'user-cog',
+                ],
+                [
+                    'label' => __('Theme & appearance'),
+                    'description' => __('Fine-tune colours, typography, and look & feel.'),
+                    'href' => '/settings/theme',
+                    'icon' => 'palette',
+                ],
+                [
+                    'label' => __('Currencies'),
+                    'description' => __('Choose the currencies you budget and report in.'),
+                    'href' => '/settings/currencies',
+                    'icon' => 'wallet',
+                ],
+                [
+                    'label' => __('Categories'),
+                    'description' => __('Organise income and spending categories.'),
+                    'href' => '/settings/categories',
+                    'icon' => 'tags',
+                ],
+            ],
+        ],
+    ];
+
+    view('more/index', [
+        'user' => $user,
+        'displayName' => $displayName,
+        'navSections' => $navSections,
+    ]);
+}

--- a/views/goals/index.php
+++ b/views/goals/index.php
@@ -394,30 +394,51 @@
       </div>
     </div>
 
-    <!-- Footer (identical to Loans) -->
-    <div class="modal-footer bg-gray-50">
-      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2 w-full">
-        <!-- Quick “Add money now” bar (matches Loans quick payment bar layout & spacing) -->
-        <div class="flex flex-col md:flex-row items-center gap-2">
-          <form method="post" action="/goals/tx/add" class="flex flex-col md:flex-row items-center gap-2">
-            <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
-            <input type="hidden" name="goal_id" value="<?= $goalId ?>" />
-            <input name="occurred_on" type="date" value="<?= date('Y-m-d') ?>" class="input">
-            <input name="amount" type="number" step="0.01" placeholder="<?= __('Amount') ?>" class="input" required>
-            <button class="w-80 btn btn-emerald"><?= __('Add money') ?></button>
-          </form>
-
-          
-        </div>
-        <!-- Danger: Delete goal (right aligned on larger screens) -->
-        <form method="post" action="/goals/delete" onsubmit="return confirm('<?= __('Delete this goal?') ?>')" class="mx-auto w-full">
+    <div class="px-6 pb-6">
+      <div class="mt-6 space-y-4">
+        <form
+          method="post"
+          action="/goals/tx/add"
+          class="grid gap-2 sm:grid-cols-3"
+        >
           <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
-          <input type="hidden" name="id" value="<?= $goalId ?>" />
-          <button class="btn btn-danger w-full"><?= __('Delete') ?></button>
+          <input type="hidden" name="goal_id" value="<?= $goalId ?>" />
+          <input
+            name="occurred_on"
+            type="date"
+            value="<?= date('Y-m-d') ?>"
+            class="input sm:col-span-1"
+          >
+          <input
+            name="amount"
+            type="number"
+            step="0.01"
+            placeholder="<?= __('Amount') ?>"
+            class="input sm:col-span-1"
+            required
+          >
+          <button class="btn btn-emerald w-full sm:w-auto sm:col-span-1">
+            <?= __('Add money') ?>
+          </button>
         </form>
 
-        <button class="btn" data-close><?= __('Cancel') ?></button>
-        <button class="btn btn-primary" onclick="document.getElementById('goal-form-<?= $goalId ?>').submit()"><?= __('Save') ?></button>
+        <form
+          method="post"
+          action="/goals/delete"
+          onsubmit="return confirm('<?= __('Delete this goal?') ?>')"
+          class="w-full"
+        >
+          <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+          <input type="hidden" name="id" value="<?= $goalId ?>" />
+          <button class="btn btn-danger w-full">
+            <?= __('Delete') ?>
+          </button>
+        </form>
+
+        <div class="flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <button class="btn" data-close><?= __('Cancel') ?></button>
+          <button class="btn btn-primary" form="goal-form-<?= $goalId ?>"><?= __('Save') ?></button>
+        </div>
       </div>
     </div>
   </div>

--- a/views/layout/header.php
+++ b/views/layout/header.php
@@ -1007,15 +1007,23 @@
     $onboarding  = str_starts_with($currentPath, '/onboard');
     $hideMenus   = ($onboarding && $currentPath !== '/onboard/done');
 
-    $items = [
-      ['href'=>'/',              'label'=>'Dashboard',      'match'=>'#^/$#',                    'icon' => 'layout-dashboard'],
-      ['href'=>'/current-month', 'label'=>'Current Month',  'match'=>'#^/current-month$#',       'icon' => 'calendar'],
-      ['href'=>'/goals',         'label'=>'Goals',          'match'=>'#^/goals(?:/.*)?$#',       'icon' => 'goal'],
-      ['href'=>'/loans',         'label'=>'Loans',          'match'=>'#^/loans(?:/.*)?$#',       'icon' => 'landmark'],
-      ['href'=>'/emergency',     'label'=>'Emergency',      'match'=>'#^/emergency(?:/.*)?$#',   'icon' => 'lifebuoy'],
-      ['href'=>'/scheduled',     'label'=>'Scheduled',      'match'=>'#^/scheduled(?:/.*)?$#',   'icon' => 'calendar-clock'],
-      ['href'=>'/feedback',      'label'=>'Feedback',       'match'=>'#^/feedback$#',            'icon' => 'message-circle'],
-      ['href'=>'/settings',      'label'=>'Settings',       'match'=>'#^/settings$#',            'icon' => 'settings'],
+    $desktopItems = [
+      ['href'=>'/',              'label'=>'Dashboard',        'match'=>'#^/$#',                    'icon' => 'layout-dashboard'],
+      ['href'=>'/current-month', 'label'=>'Current Month',    'match'=>'#^/current-month$#',       'icon' => 'calendar'],
+      ['href'=>'/goals',         'label'=>'Goals',            'match'=>'#^/goals(?:/.*)?$#',       'icon' => 'goal'],
+      ['href'=>'/loans',         'label'=>'Loans',            'match'=>'#^/loans(?:/.*)?$#',       'icon' => 'landmark'],
+      ['href'=>'/emergency',     'label'=>'Emergency Fund',   'match'=>'#^/emergency(?:/.*)?$#',   'icon' => 'lifebuoy'],
+      ['href'=>'/scheduled',     'label'=>'Scheduled',        'match'=>'#^/scheduled(?:/.*)?$#',   'icon' => 'calendar-clock'],
+      ['href'=>'/feedback',      'label'=>'Feedback',         'match'=>'#^/feedback$#',            'icon' => 'message-circle'],
+      ['href'=>'/settings',      'label'=>'Settings',         'match'=>'#^/settings$#',            'icon' => 'settings'],
+      ['href'=>'/more',          'label'=>'More',             'match'=>'#^/more(?:/.*)?$#',        'icon' => 'ellipsis'],
+    ];
+    $mobileNavItems = [
+      ['href'=>'/',              'label'=>'Dashboard',      'match'=>'#^/$#',                                         'icon' => 'layout-dashboard'],
+      ['href'=>'/years',         'label'=>'Months',         'match'=>'#^/(current-month|years(?:/.*)?|months(?:/.*)?)$#', 'icon' => 'calendar-range'],
+      ['href'=>'/goals',         'label'=>'Goals',          'match'=>'#^/goals(?:/.*)?$#',                              'icon' => 'goal'],
+      ['href'=>'/emergency',     'label'=>'Emergency Fund', 'match'=>'#^/emergency(?:/.*)?$#',                          'icon' => 'lifebuoy'],
+      ['href'=>'/more',          'label'=>'More',           'match'=>'#^/more(?:/.*)?$#',                               'icon' => 'ellipsis'],
     ];
     function nav_link(array $item, string $currentPath, string $extra=''): string {
       $active = preg_match($item['match'], $currentPath) === 1;
@@ -1041,7 +1049,7 @@
       <?php if (!$hideMenus): ?>
         <nav class="hidden items-center gap-3 text-sm sm:flex">
           <?php if (is_logged_in()): ?>
-            <?php foreach ($items as $it): echo nav_link($it, $currentPath); endforeach; ?>
+            <?php foreach ($desktopItems as $it): echo nav_link($it, $currentPath); endforeach; ?>
             <button type="button" class="icon-btn" @click="toggleTheme()" x-data="{}">
               <span class="sr-only">Toggle theme</span>
               <span x-cloak x-show="theme === 'light'" class="inline-flex">
@@ -1072,7 +1080,7 @@
           <div x-cloak x-show="open" @click.outside="open=false" x-transition class="absolute right-0 mt-3 w-64 space-y-2 rounded-3xl border border-white/70 bg-white/95 p-3 shadow-glass backdrop-blur-xl dark:border-slate-800/80 dark:bg-slate-900/90">
             <?php if (is_logged_in()): ?>
               <div class="grid gap-2 text-sm">
-                <?php foreach ($items as $it): ?>
+                <?php foreach ($desktopItems as $it): ?>
                   <?= nav_link($it, $currentPath, 'w-full') ?>
                 <?php endforeach; ?>
                 <button type="button" class="icon-btn w-full justify-center" @click="toggleTheme(); open=false">
@@ -1107,7 +1115,7 @@
     aria-label="<?= htmlspecialchars(__('Primary navigation'), ENT_QUOTES) ?>"
   >
     <ul class="mobile-nav__items w-full justify-between">
-      <?php foreach ($items as $it):
+      <?php foreach ($mobileNavItems as $it):
         $active = preg_match($it['match'], $currentPath) === 1;
         $label = __($it['label']);
         $icon  = $it['icon'] ?? 'circle';
@@ -1129,27 +1137,6 @@
           </a>
         </li>
       <?php endforeach; ?>
-        <li class="flex-1 min-w-[4.5rem]">
-          <button
-            type="button"
-            class="mobile-nav__link"
-            @click="toggleTheme()"
-            title="<?= htmlspecialchars(__('Toggle theme')) ?>"
-            aria-label="<?= htmlspecialchars(__('Toggle theme')) ?>"
-          >
-            <span class="flex h-9 w-9 items-center justify-center rounded-full border border-white/60 bg-white/80 shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
-              <span x-cloak x-show="theme === 'light'" class="inline-flex">
-                <i data-lucide="sun" class="h-4 w-4"></i>
-              </span>
-              <span x-cloak x-show="theme === 'dark'" class="inline-flex">
-                <i data-lucide="moon" class="h-4 w-4"></i>
-              </span>
-            </span>
-            <span class="text-[0.65rem] leading-3 tracking-wide uppercase">
-              <?= __('Theme') ?>
-            </span>
-          </button>
-        </li>
     </ul>
   </nav>
 <?php endif; ?>

--- a/views/layout/header.php
+++ b/views/layout/header.php
@@ -685,6 +685,7 @@
   </style>
 
   <style type="text/tailwindcss">
+    @layer components {
       .mobile-nav {
         padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
         box-shadow: 0 -20px 36px -24px rgba(17, 36, 29, 0.45);

--- a/views/layout/header.php
+++ b/views/layout/header.php
@@ -781,6 +781,24 @@
         theme: document.documentElement.dataset.theme || (document.documentElement.classList.contains('dark') ? 'dark' : 'light'),
         init() {
           this.applyTheme(this.theme, true);
+          document.addEventListener('mymoneymap:set-theme', (event) => {
+            const requested = event && event.detail ? event.detail.theme : null;
+            if (requested) {
+              this.applyTheme(requested);
+            }
+          });
+          const self = this;
+          window.MyMoneyMapThemeController = {
+            apply(mode) {
+              self.applyTheme(mode);
+            },
+            toggle() {
+              self.toggleTheme();
+            },
+            current() {
+              return self.theme;
+            }
+          };
         },
         applyTheme(value, isInit = false) {
           const previous = document.documentElement.dataset.theme;
@@ -788,6 +806,9 @@
           document.documentElement.dataset.theme = value;
           document.documentElement.classList.toggle('dark', value === 'dark');
           try { localStorage.setItem('mymoneymap-theme', value); } catch (e) {}
+          if (window.MyMoneyMapThemeController) {
+            window.MyMoneyMapThemeController.theme = value;
+          }
           if (isInit || previous !== value) {
             document.dispatchEvent(new CustomEvent('themechange', { detail: { theme: value } }));
           }
@@ -1012,7 +1033,7 @@
       ['href'=>'/current-month', 'label'=>'Current Month',    'match'=>'#^/current-month$#',       'icon' => 'calendar'],
       ['href'=>'/goals',         'label'=>'Goals',            'match'=>'#^/goals(?:/.*)?$#',       'icon' => 'goal'],
       ['href'=>'/loans',         'label'=>'Loans',            'match'=>'#^/loans(?:/.*)?$#',       'icon' => 'landmark'],
-      ['href'=>'/emergency',     'label'=>'Emergency Fund',   'match'=>'#^/emergency(?:/.*)?$#',   'icon' => 'lifebuoy'],
+      ['href'=>'/emergency',     'label'=>'Emergency Fund',   'match'=>'#^/emergency(?:/.*)?$#',   'icon' => 'life-buoy'],
       ['href'=>'/scheduled',     'label'=>'Scheduled',        'match'=>'#^/scheduled(?:/.*)?$#',   'icon' => 'calendar-clock'],
       ['href'=>'/feedback',      'label'=>'Feedback',         'match'=>'#^/feedback$#',            'icon' => 'message-circle'],
       ['href'=>'/settings',      'label'=>'Settings',         'match'=>'#^/settings$#',            'icon' => 'settings'],
@@ -1022,7 +1043,7 @@
       ['href'=>'/',              'label'=>'Dashboard',      'match'=>'#^/$#',                                         'icon' => 'layout-dashboard'],
       ['href'=>'/years',         'label'=>'Months',         'match'=>'#^/(current-month|years(?:/.*)?|months(?:/.*)?)$#', 'icon' => 'calendar-range'],
       ['href'=>'/goals',         'label'=>'Goals',          'match'=>'#^/goals(?:/.*)?$#',                              'icon' => 'goal'],
-      ['href'=>'/emergency',     'label'=>'Emergency Fund', 'match'=>'#^/emergency(?:/.*)?$#',                          'icon' => 'lifebuoy'],
+      ['href'=>'/emergency',     'label'=>'Emergency Fund', 'match'=>'#^/emergency(?:/.*)?$#',                          'icon' => 'life-buoy'],
       ['href'=>'/more',          'label'=>'More',           'match'=>'#^/more(?:/.*)?$#',                               'icon' => 'ellipsis'],
     ];
     function nav_link(array $item, string $currentPath, string $extra=''): string {
@@ -1036,7 +1057,7 @@
     }
   ?>
 <?php if (is_logged_in()): ?>
-  <header class="sticky top-0 z-40 border-b border-white/40 bg-white/60 backdrop-blur-xl transition dark:border-slate-800/60 dark:bg-slate-900/50">
+  <header class="sticky top-0 z-40 border-b border-white/40 bg-white/60 backdrop-blur-xl transition dark:border-slate-800/60 dark:bg-slate-900/50 hidden md:block">
     <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
       <a href="/" class="flex items-center gap-3 text-lg font-semibold tracking-tight text-slate-900 dark:text-white">
         <div class="h-12 w-12 p-2 rounded-xl bg-brand-500 flex flex-col items-center justify-center">

--- a/views/layout/header.php
+++ b/views/layout/header.php
@@ -193,6 +193,11 @@
           pointer-events: none;
           transform: translateY(-0.75rem);
         }
+        body.overlay-open .mobile-nav {
+          transform: translateY(calc(100% + 1.5rem));
+          opacity: 0;
+          pointer-events: none;
+        }
       }
       main {
         @apply flex-1;
@@ -689,6 +694,7 @@
       .mobile-nav {
         padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
         box-shadow: 0 -20px 36px -24px rgba(17, 36, 29, 0.45);
+        transition: transform 0.3s ease, opacity 0.3s ease;
       }
       .dark .mobile-nav {
         box-shadow: 0 -20px 40px -26px rgba(0, 0, 0, 0.65);
@@ -1040,11 +1046,11 @@
       ['href'=>'/more',          'label'=>'More',             'match'=>'#^/more(?:/.*)?$#',        'icon' => 'ellipsis'],
     ];
     $mobileNavItems = [
-      ['href'=>'/',              'label'=>'Dashboard',      'match'=>'#^/$#',                                         'icon' => 'layout-dashboard'],
-      ['href'=>'/years',         'label'=>'Months',         'match'=>'#^/(current-month|years(?:/.*)?|months(?:/.*)?)$#', 'icon' => 'calendar-range'],
-      ['href'=>'/goals',         'label'=>'Goals',          'match'=>'#^/goals(?:/.*)?$#',                              'icon' => 'goal'],
-      ['href'=>'/emergency',     'label'=>'Emergency Fund', 'match'=>'#^/emergency(?:/.*)?$#',                          'icon' => 'life-buoy'],
-      ['href'=>'/more',          'label'=>'More',           'match'=>'#^/more(?:/.*)?$#',                               'icon' => 'ellipsis'],
+      ['href'=>'/',              'label'=>'Dashboard',      'match'=>'#^/$#',                                                        'icon' => 'layout-dashboard'],
+      ['href'=>'/current-month', 'label'=>'Current month',  'match'=>'#^/(current-month(?:/.*)?|months(?:/.*)?|years(?:/.*)?)$#', 'icon' => 'calendar-range'],
+      ['href'=>'/goals',         'label'=>'Goals',          'match'=>'#^/goals(?:/.*)?$#',                                           'icon' => 'goal'],
+      ['href'=>'/emergency',     'label'=>'Emergency Fund', 'match'=>'#^/emergency(?:/.*)?$#',                                       'icon' => 'life-buoy'],
+      ['href'=>'/more',          'label'=>'More',           'match'=>'#^/more(?:/.*)?$#',                                            'icon' => 'ellipsis'],
     ];
     function nav_link(array $item, string $currentPath, string $extra=''): string {
       $active = preg_match($item['match'], $currentPath) === 1;

--- a/views/loans/index.php
+++ b/views/loans/index.php
@@ -328,7 +328,7 @@
     </div>
 
     <!-- Body -->
-    <form method="post" action="/loans/edit" class="modal-body grid gap-4 md:grid-cols-12">
+    <form method="post" action="/loans/edit" id="loan-form-<?= (int)$l['id'] ?>" class="modal-body grid gap-4 md:grid-cols-12">
       <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
       <input type="hidden" name="id" value="<?= (int)$l['id'] ?>" />
 
@@ -542,22 +542,37 @@
 
     </form>
 
-    <!-- Sticky footer -->
-    <div class="modal-footer bg-gray-50">
-      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2 w-full">
-        <!-- Quick payment -->
-        <form class="grid grid-cols-2 md:grid-cols-4 gap-2 w-full md:w-auto"
-              method="post" action="/loans/payment/add">
+    <div class="px-6 pb-6">
+      <div class="mt-6 space-y-4">
+        <form
+          class="grid gap-2 sm:grid-cols-2 lg:grid-cols-5"
+          method="post"
+          action="/loans/payment/add"
+        >
           <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
           <input type="hidden" name="loan_id" value="<?= (int)$l['id'] ?>" />
-          <input name="paid_on" type="date" value="<?= date('Y-m-d') ?>" class="input">
-          <input name="amount" type="number" step="0.01" placeholder="<?= __('Payment amount') ?>" class="input" required>
-          <button class="btn btn-emerald md:col-span-1"><?= __('Record Payment') ?></button>
+          <input
+            name="paid_on"
+            type="date"
+            value="<?= date('Y-m-d') ?>"
+            class="input sm:col-span-1 lg:col-span-2"
+          >
+          <input
+            name="amount"
+            type="number"
+            step="0.01"
+            placeholder="<?= __('Payment amount') ?>"
+            class="input sm:col-span-1 lg:col-span-2"
+            required
+          >
+          <button class="btn btn-emerald w-full sm:w-auto sm:col-span-2 lg:col-span-1">
+            <?= __('Record Payment') ?>
+          </button>
         </form>
 
-        <div class="flex justify-end gap-2">
+        <div class="flex flex-col gap-2 sm:flex-row sm:justify-end">
           <button class="btn" data-close><?= __('Cancel') ?></button>
-          <button class="btn btn-primary" onclick="this.closest('.modal').querySelector('form').submit()"><?= __('Save') ?></button>
+          <button class="btn btn-primary" form="loan-form-<?= (int)$l['id'] ?>"><?= __('Save') ?></button>
         </div>
       </div>
     </div>

--- a/views/more/index.php
+++ b/views/more/index.php
@@ -1,0 +1,140 @@
+<?php
+/** @var array $user */
+/** @var string $displayName */
+/** @var array $navSections */
+
+$email = trim($user['email'] ?? '');
+$firstSource = $displayName ?: $email;
+$firstChar = '';
+if ($firstSource !== '') {
+    $firstChar = function_exists('mb_substr') ? mb_substr($firstSource, 0, 1) : substr($firstSource, 0, 1);
+}
+$initial = strtoupper($firstChar ?: '?');
+?>
+
+<div class="mx-auto flex w-full max-w-3xl flex-col gap-10 pb-28">
+  <section class="rounded-4xl border border-white/60 bg-white/80 p-6 shadow-glass backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-900/70">
+    <div class="flex items-center gap-5">
+      <div class="flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br from-brand-400/90 to-brand-600/90 text-2xl font-semibold tracking-tight text-white shadow-brand-glow">
+        <?= htmlspecialchars($initial) ?>
+      </div>
+      <div class="flex-1">
+        <p class="text-sm font-medium uppercase tracking-[0.2em] text-slate-500/80 dark:text-slate-300/60"><?= __('Signed in as') ?></p>
+        <p class="mt-1 text-2xl font-semibold text-slate-900 dark:text-white"><?= htmlspecialchars($displayName) ?></p>
+        <?php if ($email && strtolower($email) !== strtolower($displayName)): ?>
+          <p class="text-sm text-slate-500 dark:text-slate-300/80"><?= htmlspecialchars($email) ?></p>
+        <?php endif; ?>
+      </div>
+      <div class="shrink-0">
+        <a href="/settings/profile" class="btn btn-muted whitespace-nowrap px-4 py-2 text-sm font-semibold">
+          <?= __('Edit profile') ?>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <section
+    class="rounded-4xl border border-white/60 bg-white/80 p-6 shadow-glass backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-900/70"
+    x-data="{
+      mode: $root.theme,
+      init() {
+        this.mode = $root.theme;
+        document.addEventListener('themechange', (event) => { this.mode = event.detail.theme; });
+      },
+      set(mode) {
+        $root.applyTheme(mode);
+        this.mode = mode;
+      }
+    }"
+    role="group"
+    aria-labelledby="more-theme-heading"
+  >
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+      <div>
+        <p class="text-sm font-medium uppercase tracking-[0.2em] text-slate-500/80 dark:text-slate-300/60"><?= __('Appearance') ?></p>
+        <h2 id="more-theme-heading" class="text-2xl font-semibold text-slate-900 dark:text-white"><?= __('Theme') ?></h2>
+        <p class="mt-1 text-sm text-slate-500 dark:text-slate-300/80"><?= __('Choose the look that feels most comfortable for your eyes.') ?></p>
+      </div>
+    </div>
+    <div class="mt-6 grid gap-4 sm:grid-cols-2">
+      <button
+        type="button"
+        class="flex items-center justify-between rounded-3xl border-2 px-4 py-3 text-left transition"
+        :class="mode === 'light' ? 'border-brand-500/80 bg-brand-50/80 text-brand-900 shadow-brand-glow' : 'border-white/40 bg-white/60 text-slate-600 dark:border-slate-700/80 dark:bg-slate-900/60 dark:text-slate-300'"
+        @click="set('light')"
+      >
+        <span class="flex items-center gap-3 text-base font-semibold">
+          <span class="flex h-10 w-10 items-center justify-center rounded-full bg-brand-500/90 text-white shadow">
+            <i data-lucide="sun" class="h-5 w-5"></i>
+          </span>
+          <?= __('Light mode') ?>
+        </span>
+        <i data-lucide="check" class="h-5 w-5" x-show="mode === 'light'"></i>
+      </button>
+      <button
+        type="button"
+        class="flex items-center justify-between rounded-3xl border-2 px-4 py-3 text-left transition"
+        :class="mode === 'dark' ? 'border-brand-400/80 bg-brand-600/20 text-brand-50 shadow-brand-glow' : 'border-white/40 bg-white/60 text-slate-600 dark:border-slate-700/80 dark:bg-slate-900/60 dark:text-slate-300'"
+        @click="set('dark')"
+      >
+        <span class="flex items-center gap-3 text-base font-semibold">
+          <span class="flex h-10 w-10 items-center justify-center rounded-full bg-slate-900/90 text-white shadow dark:bg-slate-800">
+            <i data-lucide="moon" class="h-5 w-5"></i>
+          </span>
+          <?= __('Dark mode') ?>
+        </span>
+        <i data-lucide="check" class="h-5 w-5" x-show="mode === 'dark'"></i>
+      </button>
+    </div>
+  </section>
+
+  <?php foreach ($navSections as $section):
+    $title = $section['title'] ?? '';
+    $items = $section['items'] ?? [];
+    if (!$items) { continue; }
+  ?>
+    <section class="space-y-4">
+      <?php if ($title): ?>
+        <h2 class="px-2 text-xs font-semibold uppercase tracking-[0.35em] text-slate-500/70 dark:text-slate-300/60">
+          <?= htmlspecialchars($title) ?>
+        </h2>
+      <?php endif; ?>
+      <div class="space-y-3" role="list">
+        <?php foreach ($items as $item):
+          $href = $item['href'] ?? '#';
+          $label = $item['label'] ?? '';
+          $description = $item['description'] ?? '';
+          $icon = $item['icon'] ?? 'circle';
+        ?>
+          <a
+            role="listitem"
+            class="group flex items-center gap-4 rounded-3xl border border-white/60 bg-white/80 p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:-translate-y-0.5 focus-visible:shadow-lg focus-visible:outline-none dark:border-slate-800/70 dark:bg-slate-900/70"
+            href="<?= htmlspecialchars($href, ENT_QUOTES) ?>"
+          >
+            <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-100/80 text-brand-700 transition group-hover:bg-brand-200 group-hover:text-brand-900 dark:bg-brand-500/15 dark:text-brand-100 dark:group-hover:bg-brand-500/25">
+              <i data-lucide="<?= htmlspecialchars($icon) ?>" class="h-5 w-5"></i>
+            </span>
+            <span class="flex-1 text-left">
+              <span class="block text-base font-semibold text-slate-900 transition group-hover:text-brand-900 dark:text-white dark:group-hover:text-brand-100">
+                <?= htmlspecialchars($label) ?>
+              </span>
+              <?php if ($description): ?>
+                <span class="mt-1 block text-sm text-slate-500 transition group-hover:text-slate-700 dark:text-slate-300/80 dark:group-hover:text-slate-200/90">
+                  <?= htmlspecialchars($description) ?>
+                </span>
+              <?php endif; ?>
+            </span>
+            <i data-lucide="chevron-right" class="h-5 w-5 text-slate-400 transition group-hover:translate-x-1 group-hover:text-brand-600 dark:text-slate-500 dark:group-hover:text-brand-200"></i>
+          </a>
+        <?php endforeach; ?>
+      </div>
+    </section>
+  <?php endforeach; ?>
+
+  <form action="/logout" method="post" class="mt-4 pt-4">
+    <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+    <button class="btn btn-primary w-full justify-center text-base font-semibold">
+      <?= __('Logout') ?>
+    </button>
+  </form>
+</div>

--- a/views/more/index.php
+++ b/views/more/index.php
@@ -2,6 +2,9 @@
 /** @var array $user */
 /** @var string $displayName */
 /** @var array $navSections */
+/** @var array $localeOptions */
+/** @var string $currentLocale */
+/** @var array $localeFlags */
 
 $email = trim($user['email'] ?? '');
 $firstSource = $displayName ?: $email;
@@ -10,23 +13,26 @@ if ($firstSource !== '') {
     $firstChar = function_exists('mb_substr') ? mb_substr($firstSource, 0, 1) : substr($firstSource, 0, 1);
 }
 $initial = strtoupper($firstChar ?: '?');
+$localeOptions = $localeOptions ?? [];
+$currentLocale = $currentLocale ?? app_locale();
+$localeFlags = $localeFlags ?? [];
 ?>
 
-<div class="mx-auto w-full max-w-3xl space-y-8 pb-28">
-  <div class="flex justify-center pt-6">
-    <span class="inline-flex h-16 w-16 items-center justify-center rounded-3xl border border-white/70 bg-white/80 p-3 shadow-glass backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-900/70">
+<div class="mx-auto w-full max-w-3xl space-y-6 px-4 pb-28 pt-6 sm:px-6 lg:px-0">
+  <div class="flex justify-center">
+    <span class="inline-flex h-16 w-16 items-center justify-center rounded-3xl border border-white/60 bg-white/80 p-3 shadow-glass backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/70">
       <img src="/logo.png" alt="App logo" class="h-full w-full object-contain" />
     </span>
   </div>
 
-  <section class="rounded-4xl border border-white/60 bg-white/80 p-6 shadow-glass backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-900/70">
-    <div class="flex flex-col items-center gap-4 text-center sm:flex-row sm:items-center sm:text-left">
+  <section class="card">
+    <div class="card-kicker text-center sm:text-left"><?= __('Signed in as') ?></div>
+    <div class="mt-4 flex flex-col items-center gap-4 text-center sm:flex-row sm:items-center sm:text-left">
       <div class="flex h-16 w-16 items-center justify-center rounded-3xl bg-gradient-to-br from-brand-400/90 to-brand-600/90 text-2xl font-semibold tracking-tight text-white shadow-brand-glow">
         <?= htmlspecialchars($initial) ?>
       </div>
       <div class="sm:flex-1">
-        <p class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-500/80 dark:text-slate-300/60"><?= __('Signed in as') ?></p>
-        <p class="mt-2 text-xl font-semibold text-slate-900 dark:text-white sm:text-2xl"><?= htmlspecialchars($displayName) ?></p>
+        <p class="text-xl font-semibold text-slate-900 dark:text-white sm:text-2xl"><?= htmlspecialchars($displayName) ?></p>
         <?php if ($email && strtolower($email) !== strtolower($displayName)): ?>
           <p class="mt-1 break-all text-sm text-slate-500 dark:text-slate-300/80"><?= htmlspecialchars($email) ?></p>
         <?php endif; ?>
@@ -41,7 +47,7 @@ $initial = strtoupper($firstChar ?: '?');
   </section>
 
   <section
-    class="rounded-4xl border border-white/60 bg-white/80 p-6 shadow-glass backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-900/70"
+    class="card"
     x-data="{
       mode: document.documentElement.dataset.theme || (document.documentElement.classList.contains('dark') ? 'dark' : 'light'),
       init() {
@@ -68,11 +74,11 @@ $initial = strtoupper($firstChar ?: '?');
     role="group"
     aria-labelledby="more-theme-heading"
   >
-    <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+    <div class="card-kicker"><?= __('Appearance') ?></div>
+    <div class="mt-2 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
       <div>
-        <p class="text-sm font-medium uppercase tracking-[0.2em] text-slate-500/80 dark:text-slate-300/60"><?= __('Appearance') ?></p>
-        <h2 id="more-theme-heading" class="text-2xl font-semibold text-slate-900 dark:text-white"><?= __('Theme') ?></h2>
-        <p class="mt-1 text-sm text-slate-500 dark:text-slate-300/80"><?= __('Choose the look that feels most comfortable for your eyes.') ?></p>
+        <h2 id="more-theme-heading" class="card-title"><?= __('Theme') ?></h2>
+        <p class="card-subtle mt-1 text-sm"><?= __('Choose the look that feels most comfortable for your eyes.') ?></p>
       </div>
     </div>
     <div class="mt-6 grid gap-3 sm:grid-cols-2">
@@ -109,53 +115,83 @@ $initial = strtoupper($firstChar ?: '?');
     </div>
   </section>
 
-  <?php foreach ($navSections as $section):
-    $title = $section['title'] ?? '';
-    $items = $section['items'] ?? [];
-    if (!$items) { continue; }
-  ?>
-    <section class="space-y-4">
-      <?php if ($title): ?>
-        <h2 class="px-2 text-xs font-semibold uppercase tracking-[0.35em] text-slate-500/70 dark:text-slate-300/60">
-          <?= htmlspecialchars($title) ?>
-        </h2>
-      <?php endif; ?>
-      <div class="space-y-3" role="list">
-        <?php foreach ($items as $item):
-          $href = $item['href'] ?? '#';
-          $label = $item['label'] ?? '';
-          $description = $item['description'] ?? '';
-          $icon = $item['icon'] ?? 'circle';
-        ?>
+  <?php if ($localeOptions): ?>
+    <section class="card" id="language">
+      <div class="card-kicker"><?= __('Preferences') ?></div>
+      <h2 class="card-title mt-1"><?= __('Language') ?></h2>
+      <p class="card-subtle mt-2 text-sm"><?= __('Choose your preferred interface language.') ?></p>
+      <div class="mt-4 grid gap-2 sm:grid-cols-2">
+        <?php foreach ($localeOptions as $code => $label): ?>
+          <?php
+          $isActive = $code === $currentLocale;
+          $flag = $localeFlags[$code] ?? '🏳️';
+          ?>
           <a
-            role="listitem"
-            class="group flex items-center gap-4 rounded-3xl border border-white/60 bg-white/80 p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:-translate-y-0.5 focus-visible:shadow-lg focus-visible:outline-none dark:border-slate-800/70 dark:bg-slate-900/70"
-            href="<?= htmlspecialchars($href, ENT_QUOTES) ?>"
+            href="<?= htmlspecialchars(url_with_lang($code), ENT_QUOTES) ?>"
+            class="flex items-center gap-3 rounded-2xl border px-3 py-2 text-sm font-semibold transition <?= $isActive ? 'border-brand-500 bg-brand-600 text-white shadow-brand-glow' : 'border-white/60 bg-white/70 text-slate-600 hover:border-brand-200 hover:bg-brand-50/70 hover:text-brand-700 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:bg-slate-800/70' ?>"
+            title="<?= htmlspecialchars($label) ?>"
+            aria-current="<?= $isActive ? 'true' : 'false' ?>"
           >
-            <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-100/80 text-brand-700 transition group-hover:bg-brand-200 group-hover:text-brand-900 dark:bg-brand-500/15 dark:text-brand-100 dark:group-hover:bg-brand-500/25">
-              <i data-lucide="<?= htmlspecialchars($icon) ?>" class="h-5 w-5"></i>
-            </span>
-            <span class="flex-1 text-left">
-              <span class="block text-base font-semibold text-slate-900 transition group-hover:text-brand-900 dark:text-white dark:group-hover:text-brand-100">
-                <?= htmlspecialchars($label) ?>
-              </span>
-              <?php if ($description): ?>
-                <span class="mt-1 block text-sm text-slate-500 transition group-hover:text-slate-700 dark:text-slate-300/80 dark:group-hover:text-slate-200/90">
-                  <?= htmlspecialchars($description) ?>
-                </span>
-              <?php endif; ?>
-            </span>
-            <i data-lucide="chevron-right" class="h-5 w-5 text-slate-400 transition group-hover:translate-x-1 group-hover:text-brand-600 dark:text-slate-500 dark:group-hover:text-brand-200"></i>
+            <span class="text-lg leading-none"><?= $flag ?></span>
+            <span><?= htmlspecialchars($label) ?></span>
           </a>
         <?php endforeach; ?>
       </div>
     </section>
+  <?php endif; ?>
+
+  <?php foreach ($navSections as $index => $section):
+    $title = trim($section['title'] ?? '');
+    $items = $section['items'] ?? [];
+    if (!$items) { continue; }
+    $sectionId = 'more-section-' . $index;
+  ?>
+    <section class="card" <?= $title ? 'aria-labelledby="' . htmlspecialchars($sectionId, ENT_QUOTES) . '"' : '' ?>>
+      <?php if ($title): ?>
+        <h2 id="<?= htmlspecialchars($sectionId, ENT_QUOTES) ?>" class="card-title">
+          <?= htmlspecialchars($title) ?>
+        </h2>
+      <?php endif; ?>
+      <div class="mt-4" role="list">
+        <div class="glass-stack" role="presentation">
+          <?php foreach ($items as $item):
+            $href = $item['href'] ?? '#';
+            $label = $item['label'] ?? '';
+            $description = $item['description'] ?? '';
+            $icon = $item['icon'] ?? 'circle';
+          ?>
+            <a
+              role="listitem"
+              class="glass-stack__item group flex items-center gap-4 text-left transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:-translate-y-0.5 focus-visible:shadow-lg focus-visible:outline-none"
+              href="<?= htmlspecialchars($href, ENT_QUOTES) ?>"
+            >
+              <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-brand-100/80 text-brand-700 transition group-hover:bg-brand-200 group-hover:text-brand-900 dark:bg-brand-500/15 dark:text-brand-100 dark:group-hover:bg-brand-500/25">
+                <i data-lucide="<?= htmlspecialchars($icon) ?>" class="h-5 w-5"></i>
+              </span>
+              <span class="flex-1">
+                <span class="block text-base font-semibold text-slate-900 transition group-hover:text-brand-900 dark:text-white dark:group-hover:text-brand-100">
+                  <?= htmlspecialchars($label) ?>
+                </span>
+                <?php if ($description): ?>
+                  <span class="mt-1 block text-sm text-slate-500 transition group-hover:text-slate-700 dark:text-slate-300/80 dark:group-hover:text-slate-200/90">
+                    <?= htmlspecialchars($description) ?>
+                  </span>
+                <?php endif; ?>
+              </span>
+              <i data-lucide="chevron-right" class="h-5 w-5 text-slate-400 transition group-hover:translate-x-1 group-hover:text-brand-600 dark:text-slate-500 dark:group-hover:text-brand-200"></i>
+            </a>
+          <?php endforeach; ?>
+        </div>
+      </div>
+    </section>
   <?php endforeach; ?>
 
-  <form action="/logout" method="post" class="mt-4 pt-4">
-    <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
-    <button class="btn btn-primary w-full justify-center text-base font-semibold">
-      <?= __('Logout') ?>
-    </button>
-  </form>
+  <section class="card">
+    <form action="/logout" method="post" class="space-y-3">
+      <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+      <button class="btn btn-primary w-full justify-center text-base font-semibold">
+        <?= __('Logout') ?>
+      </button>
+    </form>
+  </section>
 </div>

--- a/views/settings/basic_incomes.php
+++ b/views/settings/basic_incomes.php
@@ -8,6 +8,12 @@
   <?php if (!empty($_SESSION['flash'])): ?>
     <p class="mt-3 text-sm text-brand-600"><?= $_SESSION['flash']; unset($_SESSION['flash']); ?></p>
   <?php endif; ?>
+  <?php
+    $categoryMap = [];
+    foreach ($categories as $catRow) {
+      $categoryMap[(int)($catRow['id'] ?? 0)] = $catRow;
+    }
+  ?>
 
     <div class="mt-6 grid md:grid-cols-12 gap-6">
     <!-- Left: Add / Raise -->
@@ -81,9 +87,7 @@
               </div>
             </div>
             <?php if (!empty($r['category_id'])):
-              // quick category chip
-              $catMap = $catMap ?? (function($categories){ $m=[]; foreach($categories as $cx){ $m[(int)$cx['id']]=$cx; } return $m; })($categories);
-              $cx = $catMap[(int)$r['category_id']] ?? null;
+              $cx = $categoryMap[(int)$r['category_id']] ?? null;
               if ($cx): ?>
                 <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-xs shrink-0">
                   <span class="inline-block h-2.5 w-2.5 rounded-full" style="background-color: <?= htmlspecialchars($cx['color']) ?>;"></span>
@@ -99,85 +103,86 @@
   </div>
 
   <!-- History -->
-  <div class="mt-8 overflow-x-auto">
-    <h2 class="font-medium mb-2"><?= __('History') ?></h2>
-    <table class="table-glass min-w-full text-sm">
-      <thead>
-        <tr class="text-left border-b">
-          <th class="py-2 pr-3"><?= __('Label') ?></th>
-          <th class="py-2 pr-3"><?= __('Category') ?></th>
-          <th class="py-2 pr-3"><?= __('Amount') ?></th>
-          <th class="py-2 pr-3"><?= __('Currency') ?></th>
-          <th class="py-2 pr-3"><?= __('Valid From') ?></th>
-          <th class="py-2 pr-3"><?= __('Valid To') ?></th>
-          <th class="py-2 pr-3"><?= __('Actions') ?></th>
-        </tr>
-      </thead>
-      <tbody>
-        <?php foreach($rows as $r): ?>
-          <tr class="border-b">
-            <td class="py-2 pr-3 font-medium"><?= htmlspecialchars($r['label']) ?></td>
-            <td class="py-2 pr-3 font-medium">
+  <div class="mt-8">
+    <h2 class="font-medium mb-3"><?= __('History') ?></h2>
+    <div class="space-y-4">
+      <?php if ($rows): foreach ($rows as $r): ?>
+        <article class="panel p-5 space-y-4">
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div class="min-w-0 space-y-2">
+              <div class="text-lg font-semibold text-gray-900 dark:text-gray-100"><?= htmlspecialchars($r['label']) ?></div>
               <?php if (!empty($r['category_id'])):
-                // build a small map once
-                $catMap = $catMap ?? (function($categories){ $m=[]; foreach($categories as $cx){ $m[(int)$cx['id']]=$cx; } return $m; })($categories);
-                $cx = $catMap[(int)$r['category_id']] ?? null;
+                $cx = $categoryMap[(int)$r['category_id']] ?? null;
                 if ($cx): ?>
-                  <div class="mt-1 text-xs">
-                    <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full border">
-                      <span class="inline-block h-2.5 w-2.5 rounded-full" style="background-color: <?= htmlspecialchars($cx['color']) ?>;"></span>
-                      <?= htmlspecialchars($cx['label']) ?>
-                    </span>
-                  </div>
-              <?php endif; endif; ?>
-            </td>
-            <td class="py-2 pr-3 font-medium"><?= moneyfmt($r['amount'], $r['currency']) ?></td>
-            <td class="py-2 pr-3"><?= htmlspecialchars($r['currency']) ?></td>
-            <td class="py-2 pr-3"><?= htmlspecialchars($r['valid_from']) ?></td>
-            <td class="py-2 pr-3"><?= htmlspecialchars($r['valid_to'] ?? '—') ?></td>
-            <td class="py-2 pr-3">
-              <details>
-                <summary class="cursor-pointer text-accent flex items-center gap-2">
-                  <span class="icon-action icon-action--primary" aria-hidden="true">
-                    <i data-lucide="pencil" class="h-4 w-4"></i>
+                  <span class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-gray-600 dark:border-slate-700 dark:bg-slate-900/40 dark:text-gray-200">
+                    <span class="inline-block h-2.5 w-2.5 rounded-full" style="background-color: <?= htmlspecialchars($cx['color']) ?>;"></span>
+                    <?= htmlspecialchars($cx['label']) ?>
                   </span>
-                  <span class="sr-only"><?= __('Edit') ?></span>
-                </summary>
-                <form class="mt-2 grid sm:grid-cols-12 gap-2" method="post" action="/settings/basic-incomes/edit">
-                  <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
-                  <input type="hidden" name="id" value="<?= $r['id'] ?>" />
-                  <input name="label"      value="<?= htmlspecialchars($r['label']) ?>" class="input sm:col-span-4" />
-                  <input name="amount"     type="number" step="0.01" value="<?= htmlspecialchars($r['amount']) ?>" class="input sm:col-span-2" />
-                  <input name="currency"   value="<?= htmlspecialchars($r['currency']) ?>" class="input sm:col-span-2" />
-                  <input name="valid_from" type="date"  value="<?= htmlspecialchars($r['valid_from']) ?>" class="input sm:col-span-2" />
-                  <input name="valid_to"   type="date"  value="<?= htmlspecialchars($r['valid_to'] ?? '') ?>" class="input sm:col-span-2" />
-                  <select name="category_id" class="select sm:col-span-4">
-                    <option value=""><?= __('No category') ?></option>
-                    <?php foreach ($categories as $c): ?>
-                      <option value="<?= (int)$c['id'] ?>" <?= ((int)($r['category_id'] ?? 0)===(int)$c['id']) ? 'selected' : '' ?>>
-                        <?= htmlspecialchars($c['label']) ?>
-                      </option>
-                    <?php endforeach; ?>
-                  </select>
-                  <div class="sm:col-span-8 flex justify-end">
-                    <button class="btn btn-primary"><?= __('Save') ?></button>
-                  </div>
-                </form>
-                <form class="mt-2" method="post" action="/settings/basic-incomes/delete"
-                      onsubmit="return confirm('<?= addslashes(__('Delete this record?')) ?>')">
-                  <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
-                  <input type="hidden" name="id" value="<?= $r['id'] ?>" />
-                  <button class="icon-action icon-action--danger" title="<?= __('Remove') ?>">
-                    <i data-lucide="trash-2" class="h-4 w-4"></i>
-                    <span class="sr-only"><?= __('Remove') ?></span>
-                  </button>
-                </form>
-              </details>
-            </td>
-          </tr>
-        <?php endforeach; ?>
-      </tbody>
-    </table>
+              <?php endif; endif; ?>
+            </div>
+            <div class="text-right leading-tight">
+              <div class="text-xl font-semibold text-gray-900 dark:text-gray-100"><?= moneyfmt($r['amount'], $r['currency']) ?></div>
+              <div class="text-xs text-gray-500 dark:text-gray-400"><?= htmlspecialchars($r['currency']) ?></div>
+            </div>
+          </div>
+          <div class="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            <span class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/60 px-3 py-1 dark:border-slate-700 dark:bg-slate-900/40">
+              <?= __('Valid from') ?>
+              <span class="font-medium text-gray-700 dark:text-gray-200"><?= htmlspecialchars($r['valid_from']) ?></span>
+            </span>
+            <span class="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/60 px-3 py-1 dark:border-slate-700 dark:bg-slate-900/40">
+              <?= __('Valid to') ?>
+              <span class="font-medium text-gray-700 dark:text-gray-200">
+                <?= $r['valid_to'] ? htmlspecialchars($r['valid_to']) : __('Ongoing') ?>
+              </span>
+            </span>
+          </div>
+          <details class="group rounded-2xl border border-dashed border-white/60 bg-white/60 p-4 transition dark:border-slate-700/70 dark:bg-slate-900/40">
+            <summary class="flex cursor-pointer items-center justify-between gap-2 text-sm font-semibold text-brand-600 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-300">
+              <span class="flex items-center gap-2">
+                <span class="icon-action icon-action--primary" aria-hidden="true">
+                  <i data-lucide="pencil" class="h-4 w-4"></i>
+                </span>
+                <?= __('Edit') ?>
+              </span>
+              <i data-lucide="chevron-down" class="h-4 w-4 transition-transform duration-200 group-open:rotate-180"></i>
+            </summary>
+            <div class="mt-3 space-y-3">
+              <form class="grid gap-2 sm:grid-cols-12" method="post" action="/settings/basic-incomes/edit">
+                <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+                <input type="hidden" name="id" value="<?= $r['id'] ?>" />
+                <input name="label" value="<?= htmlspecialchars($r['label']) ?>" class="input sm:col-span-4" />
+                <input name="amount" type="number" step="0.01" value="<?= htmlspecialchars($r['amount']) ?>" class="input sm:col-span-2" />
+                <input name="currency" value="<?= htmlspecialchars($r['currency']) ?>" class="input sm:col-span-2" />
+                <input name="valid_from" type="date" value="<?= htmlspecialchars($r['valid_from']) ?>" class="input sm:col-span-2" />
+                <input name="valid_to" type="date" value="<?= htmlspecialchars($r['valid_to'] ?? '') ?>" class="input sm:col-span-2" />
+                <select name="category_id" class="select sm:col-span-4">
+                  <option value=""><?= __('No category') ?></option>
+                  <?php foreach ($categories as $c): ?>
+                    <option value="<?= (int)$c['id'] ?>" <?= ((int)($r['category_id'] ?? 0)===(int)$c['id']) ? 'selected' : '' ?>>
+                      <?= htmlspecialchars($c['label']) ?>
+                    </option>
+                  <?php endforeach; ?>
+                </select>
+                <div class="sm:col-span-12 flex justify-end">
+                  <button class="btn btn-primary"><?= __('Save') ?></button>
+                </div>
+              </form>
+              <form class="flex justify-end" method="post" action="/settings/basic-incomes/delete"
+                    onsubmit="return confirm('<?= addslashes(__('Delete this record?')) ?>')">
+                <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+                <input type="hidden" name="id" value="<?= $r['id'] ?>" />
+                <button class="icon-action icon-action--danger" title="<?= __('Remove') ?>">
+                  <i data-lucide="trash-2" class="h-4 w-4"></i>
+                  <span class="sr-only"><?= __('Remove') ?></span>
+                </button>
+              </form>
+            </div>
+          </details>
+        </article>
+      <?php endforeach; else: ?>
+        <div class="panel p-5 text-sm text-gray-500 dark:text-gray-400"><?= __('No basic incomes yet.') ?></div>
+      <?php endif; ?>
     </div>
   </div>
 </section>

--- a/views/settings/basic_incomes.php
+++ b/views/settings/basic_incomes.php
@@ -2,11 +2,16 @@
   <div class="card">
     <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
       <h1 class="text-xl font-semibold"><?= __('Manage Basic Incomes') ?></h1>
-      <a href="/settings" class="inline-flex items-center gap-1 text-sm font-medium text-accent">
-        <span aria-hidden="true">←</span>
-        <span class="hidden sm:inline"><?= __('Back to Settings') ?></span>
-        <span class="sm:hidden"><?= __('Back to More') ?></span>
-      </a>
+      <div class="flex items-center gap-2">
+        <a href="/settings" class="hidden sm:inline-flex items-center gap-1 text-sm font-medium text-accent">
+          <span aria-hidden="true">←</span>
+          <span><?= __('Back to Settings') ?></span>
+        </a>
+        <a href="/more" class="inline-flex sm:hidden items-center gap-1 text-sm font-medium text-accent">
+          <span aria-hidden="true">←</span>
+          <span><?= __('Back to More') ?></span>
+        </a>
+      </div>
     </div>
 
   <?php if (!empty($_SESSION['flash'])): ?>

--- a/views/settings/basic_incomes.php
+++ b/views/settings/basic_incomes.php
@@ -1,8 +1,12 @@
 <section class="max-w-5xl mx-auto">
   <div class="card">
-    <div class="flex items-center justify-between">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
       <h1 class="text-xl font-semibold"><?= __('Manage Basic Incomes') ?></h1>
-      <a href="/settings" class="text-sm text-accent"><?= __('← Back to Settings') ?></a>
+      <a href="/settings" class="inline-flex items-center gap-1 text-sm font-medium text-accent">
+        <span aria-hidden="true">←</span>
+        <span class="hidden sm:inline"><?= __('Back to Settings') ?></span>
+        <span class="sm:hidden"><?= __('Back to More') ?></span>
+      </a>
     </div>
 
   <?php if (!empty($_SESSION['flash'])): ?>

--- a/views/settings/cashflow.php
+++ b/views/settings/cashflow.php
@@ -2,11 +2,16 @@
   <div class="card space-y-6">
     <div class="flex items-center justify-between">
       <h1 class="text-xl font-semibold"><?= __('Cashflow Rules') ?></h1>
-      <a href="/settings" class="inline-flex items-center gap-1 text-sm font-medium text-accent">
-        <span aria-hidden="true">←</span>
-        <span class="hidden sm:inline"><?= __('Back to Settings') ?></span>
-        <span class="sm:hidden"><?= __('Back to More') ?></span>
-      </a>
+      <div class="flex items-center gap-2">
+        <a href="/settings" class="hidden sm:inline-flex items-center gap-1 text-sm font-medium text-accent">
+          <span aria-hidden="true">←</span>
+          <span><?= __('Back to Settings') ?></span>
+        </a>
+        <a href="/more" class="inline-flex sm:hidden items-center gap-1 text-sm font-medium text-accent">
+          <span aria-hidden="true">←</span>
+          <span><?= __('Back to More') ?></span>
+        </a>
+      </div>
     </div>
 
     <?php

--- a/views/settings/cashflow.php
+++ b/views/settings/cashflow.php
@@ -2,7 +2,11 @@
   <div class="card space-y-6">
     <div class="flex items-center justify-between">
       <h1 class="text-xl font-semibold"><?= __('Cashflow Rules') ?></h1>
-      <a href="/settings" class="text-sm text-accent"><?= __('← Back to Settings') ?></a>
+      <a href="/settings" class="inline-flex items-center gap-1 text-sm font-medium text-accent">
+        <span aria-hidden="true">←</span>
+        <span class="hidden sm:inline"><?= __('Back to Settings') ?></span>
+        <span class="sm:hidden"><?= __('Back to More') ?></span>
+      </a>
     </div>
 
     <?php

--- a/views/settings/categories.php
+++ b/views/settings/categories.php
@@ -2,11 +2,16 @@
   <div class="card space-y-6">
     <div class="flex items-center justify-between">
       <h1 class="text-xl font-semibold"><?= __('Manage Categories') ?></h1>
-      <a href="/settings" class="inline-flex items-center gap-1 text-sm font-medium text-accent">
-        <span aria-hidden="true">←</span>
-        <span class="hidden sm:inline"><?= __('Back to Settings') ?></span>
-        <span class="sm:hidden"><?= __('Back to More') ?></span>
-      </a>
+      <div class="flex items-center gap-2">
+        <a href="/settings" class="hidden sm:inline-flex items-center gap-1 text-sm font-medium text-accent">
+          <span aria-hidden="true">←</span>
+          <span><?= __('Back to Settings') ?></span>
+        </a>
+        <a href="/more" class="inline-flex sm:hidden items-center gap-1 text-sm font-medium text-accent">
+          <span aria-hidden="true">←</span>
+          <span><?= __('Back to More') ?></span>
+        </a>
+      </div>
     </div>
 
     <div class="grid gap-6 md:grid-cols-2">

--- a/views/settings/categories.php
+++ b/views/settings/categories.php
@@ -2,7 +2,11 @@
   <div class="card space-y-6">
     <div class="flex items-center justify-between">
       <h1 class="text-xl font-semibold"><?= __('Manage Categories') ?></h1>
-      <a href="/settings" class="text-sm text-accent"><?= __('← Back to Settings') ?></a>
+      <a href="/settings" class="inline-flex items-center gap-1 text-sm font-medium text-accent">
+        <span aria-hidden="true">←</span>
+        <span class="hidden sm:inline"><?= __('Back to Settings') ?></span>
+        <span class="sm:hidden"><?= __('Back to More') ?></span>
+      </a>
     </div>
 
     <div class="grid gap-6 md:grid-cols-2">

--- a/views/settings/currencies.php
+++ b/views/settings/currencies.php
@@ -2,7 +2,11 @@
   <div class="card space-y-6">
     <div class="flex items-center justify-between">
       <h1 class="text-xl font-semibold"><?= __('Manage Currencies') ?></h1>
-      <a href="/settings" class="text-sm text-accent"><?= __('← Back to Settings') ?></a>
+      <a href="/settings" class="inline-flex items-center gap-1 text-sm font-medium text-accent">
+        <span aria-hidden="true">←</span>
+        <span class="hidden sm:inline"><?= __('Back to Settings') ?></span>
+        <span class="sm:hidden"><?= __('Back to More') ?></span>
+      </a>
     </div>
 
     <div class="grid gap-6 md:grid-cols-2">

--- a/views/settings/currencies.php
+++ b/views/settings/currencies.php
@@ -2,11 +2,16 @@
   <div class="card space-y-6">
     <div class="flex items-center justify-between">
       <h1 class="text-xl font-semibold"><?= __('Manage Currencies') ?></h1>
-      <a href="/settings" class="inline-flex items-center gap-1 text-sm font-medium text-accent">
-        <span aria-hidden="true">←</span>
-        <span class="hidden sm:inline"><?= __('Back to Settings') ?></span>
-        <span class="sm:hidden"><?= __('Back to More') ?></span>
-      </a>
+      <div class="flex items-center gap-2">
+        <a href="/settings" class="hidden sm:inline-flex items-center gap-1 text-sm font-medium text-accent">
+          <span aria-hidden="true">←</span>
+          <span><?= __('Back to Settings') ?></span>
+        </a>
+        <a href="/more" class="inline-flex sm:hidden items-center gap-1 text-sm font-medium text-accent">
+          <span aria-hidden="true">←</span>
+          <span><?= __('Back to More') ?></span>
+        </a>
+      </div>
     </div>
 
     <div class="grid gap-6 md:grid-cols-2">

--- a/views/settings/index.php
+++ b/views/settings/index.php
@@ -74,7 +74,7 @@ $localeFlags = [
 
   <?php if ($localeOptions): ?>
   <!-- Language -->
-  <div class="card">
+  <div class="card" id="language">
     <div class="card-kicker"><?= __('Preferences') ?></div>
     <h2 class="card-title mt-1"><?= __('Language') ?></h2>
     <p class="card-subtle mt-2"><?= __('Choose your preferred interface language.') ?></p>

--- a/views/settings/profile.php
+++ b/views/settings/profile.php
@@ -2,11 +2,16 @@
   <div class="card">
     <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
       <h1 class="text-xl font-semibold">Profile</h1>
-      <a href="/settings" class="inline-flex items-center gap-1 text-sm font-medium text-accent">
-        <span aria-hidden="true">←</span>
-        <span class="hidden sm:inline"><?= __('Back to Settings') ?></span>
-        <span class="sm:hidden"><?= __('Back to More') ?></span>
-      </a>
+      <div class="flex items-center gap-2">
+        <a href="/settings" class="hidden sm:inline-flex items-center gap-1 text-sm font-medium text-accent">
+          <span aria-hidden="true">←</span>
+          <span><?= __('Back to Settings') ?></span>
+        </a>
+        <a href="/more" class="inline-flex sm:hidden items-center gap-1 text-sm font-medium text-accent">
+          <span aria-hidden="true">←</span>
+          <span><?= __('Back to More') ?></span>
+        </a>
+      </div>
     </div>
 
     <?php if (!empty($_SESSION['flash'])): ?>

--- a/views/settings/profile.php
+++ b/views/settings/profile.php
@@ -1,8 +1,12 @@
 <section class="max-w-2xl mx-auto">
   <div class="card">
-    <div class="flex items-center justify-between">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
       <h1 class="text-xl font-semibold">Profile</h1>
-      <a href="/settings" class="text-sm text-accent">← Back to Settings</a>
+      <a href="/settings" class="inline-flex items-center gap-1 text-sm font-medium text-accent">
+        <span aria-hidden="true">←</span>
+        <span class="hidden sm:inline"><?= __('Back to Settings') ?></span>
+        <span class="sm:hidden"><?= __('Back to More') ?></span>
+      </a>
     </div>
 
     <?php if (!empty($_SESSION['flash'])): ?>

--- a/views/settings/theme.php
+++ b/views/settings/theme.php
@@ -23,11 +23,16 @@ $currentMeta = $currentMeta ?? theme_meta($currentTheme) ?? [];
           </p>
         </noscript>
       </div>
-      <a href="/settings" class="inline-flex items-center gap-1 text-sm font-medium text-accent">
-        <span aria-hidden="true">←</span>
-        <span class="hidden sm:inline"><?= __('Back to Settings') ?></span>
-        <span class="sm:hidden"><?= __('Back to More') ?></span>
-      </a>
+      <div class="flex items-center gap-2">
+        <a href="/settings" class="hidden sm:inline-flex items-center gap-1 text-sm font-medium text-accent">
+          <span aria-hidden="true">←</span>
+          <span><?= __('Back to Settings') ?></span>
+        </a>
+        <a href="/more" class="inline-flex sm:hidden items-center gap-1 text-sm font-medium text-accent">
+          <span aria-hidden="true">←</span>
+          <span><?= __('Back to More') ?></span>
+        </a>
+      </div>
     </div>
 
     <?php if (!empty($_SESSION['flash'])): ?>

--- a/views/settings/theme.php
+++ b/views/settings/theme.php
@@ -23,7 +23,11 @@ $currentMeta = $currentMeta ?? theme_meta($currentTheme) ?? [];
           </p>
         </noscript>
       </div>
-      <a href="/settings" class="text-sm text-accent">← <?= __('Back to Settings') ?></a>
+      <a href="/settings" class="inline-flex items-center gap-1 text-sm font-medium text-accent">
+        <span aria-hidden="true">←</span>
+        <span class="hidden sm:inline"><?= __('Back to Settings') ?></span>
+        <span class="sm:hidden"><?= __('Back to More') ?></span>
+      </a>
     </div>
 
     <?php if (!empty($_SESSION['flash'])): ?>

--- a/views/settings/theme.php
+++ b/views/settings/theme.php
@@ -46,22 +46,20 @@ $currentMeta = $currentMeta ?? theme_meta($currentTheme) ?? [];
             $accent = $meta['accent'] ?? $primary;
             $description = trim($meta['description'] ?? '');
           ?>
-          <label class="group relative block cursor-pointer rounded-3xl border transition-all duration-200 p-5 backdrop-blur hover:-translate-y-1 <?= $isActive ? 'border-brand-500 bg-white/85 shadow-brand-glow dark:bg-slate-900/70' : 'border-white/60 bg-white/60 hover:border-brand-200 hover:bg-brand-50/60 dark:border-slate-700 dark:bg-slate-900/40 dark:hover:bg-slate-800/80' ?>">
+          <label class="group relative block cursor-pointer rounded-3xl border transition-all duration-200 p-5 backdrop-blur hover:-translate-y-1 focus-within:outline focus-within:outline-2 focus-within:outline-brand-300 <?= $isActive ? 'border-brand-500 bg-white/85 shadow-brand-glow dark:bg-slate-900/70' : 'border-white/60 bg-white/60 hover:border-brand-200 hover:bg-brand-50/60 dark:border-slate-700 dark:bg-slate-900/40 dark:hover:bg-slate-800/80' ?>">
           <input type="radio" name="theme" value="<?= htmlspecialchars($slug) ?>" class="sr-only" <?= $isActive ? 'checked' : '' ?> data-theme-choice>
-          <div class="flex items-start justify-between gap-4">
-            <div>
+          <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+            <div class="min-w-0 space-y-2">
               <div class="text-xs font-semibold uppercase tracking-[0.28em] text-brand-700 dark:text-brand-200">#<?= str_pad(strtoupper(str_replace('-', '', $slug)), 6, '•') ?></div>
-              <div class="mt-2 text-lg font-semibold text-gray-800 dark:text-gray-100"><?= htmlspecialchars($meta['name'] ?? $slug) ?></div>
+              <div class="text-lg font-semibold text-gray-800 dark:text-gray-100 break-words"><?= htmlspecialchars($meta['name'] ?? $slug) ?></div>
               <?php if ($description !== ''): ?>
-                <p class="mt-2 text-sm text-gray-600 dark:text-gray-300 leading-relaxed"><?= htmlspecialchars($description) ?></p>
+                <p class="text-sm text-gray-600 dark:text-gray-300 leading-relaxed"><?= htmlspecialchars($description) ?></p>
               <?php endif; ?>
             </div>
-            <div class="flex-shrink-0">
-              <div class="flex items-center gap-2">
-                <span class="h-10 w-10 rounded-2xl border border-white/50 shadow-sm" style="background: <?= htmlspecialchars($lightSwatch) ?>"></span>
-                <span class="h-10 w-10 rounded-2xl border border-white/40 shadow-sm" style="background: linear-gradient(135deg, <?= htmlspecialchars($primary) ?>, <?= htmlspecialchars($accent) ?>);"></span>
-                <span class="h-10 w-10 rounded-2xl border border-white/30 shadow-sm" style="background: <?= htmlspecialchars($darkSwatch) ?>"></span>
-              </div>
+            <div class="flex flex-wrap items-center gap-3 sm:flex-nowrap sm:gap-2">
+              <span class="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/50 shadow-sm" style="background: <?= htmlspecialchars($lightSwatch) ?>"></span>
+              <span class="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/40 shadow-sm" style="background: linear-gradient(135deg, <?= htmlspecialchars($primary) ?>, <?= htmlspecialchars($accent) ?>);"></span>
+              <span class="flex h-10 w-10 items-center justify-center rounded-2xl border border-white/30 shadow-sm" style="background: <?= htmlspecialchars($darkSwatch) ?>"></span>
             </div>
           </div>
           <div class="mt-4 grid grid-cols-2 gap-2 text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-300">


### PR DESCRIPTION
## Summary
- lock viewport interactions for mobile, add a fixed bottom navigation, and style helpers for the mobile shell
- move goal and loan quick-action forms into the scrollable dialog body for better mobile ergonomics
- refresh theme tiles and convert the basic incomes history into responsive cards that avoid horizontal overflow

## Testing
- php -l views/layout/header.php
- php -l views/loans/index.php
- php -l views/goals/index.php
- php -l views/settings/theme.php
- php -l views/settings/basic_incomes.php

------
https://chatgpt.com/codex/tasks/task_e_68d456ca2c34832992a794480597fcbf