### PR TITLE
Fix production deploy rsync step

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -12,19 +12,25 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
-            - name: Trust Nethely host key
+            - name: Prepare SSH key
               run: |
                   mkdir -p ~/.ssh
+                  printf '%s\n' "${{ secrets.NETHELY_SSH_KEY }}" > ~/.ssh/id_rsa
+                  chmod 600 ~/.ssh/id_rsa
                   ssh-keyscan -p "${{ secrets.NETHELY_SSH_PORT }}" "${{ secrets.NETHELY_SSH_HOST }}" >> ~/.ssh/known_hosts
                   chmod 600 ~/.ssh/known_hosts
 
             - name: Upload files via rsync
-              uses: appleboy/ssh-action@v1.0.3
-              with:
-                  host: ${{ secrets.NETHELY_SSH_HOST }}
-                  username: ${{ secrets.NETHELY_SSH_USER }}
-                  key: ${{ secrets.NETHELY_SSH_KEY }}
-                  passphrase: ${{ secrets.NETHELY_SSH_PASSPHRASE }}
-                  port: ${{ secrets.NETHELY_SSH_PORT }}
-                  script: |
-                      set -euo pipefail
+              env:
+                  RSYNC_RSH: ssh -i ~/.ssh/id_rsa -p ${{ secrets.NETHELY_SSH_PORT }} -o StrictHostKeyChecking=yes
+              run: |
+                  set -euo pipefail
+                  rsync \
+                      -az \
+                      --delete \
+                      --exclude='.git/' \
+                      --exclude='.github/' \
+                      --exclude='.env' \
+                      --exclude='.env.*' \
+                      -e "$RSYNC_RSH" \
+                      ./ "${{ secrets.NETHELY_SSH_USER }}@${{ secrets.NETHELY_SSH_HOST }}:${{ secrets.NETHELY_DEPLOY_PATH }}"


### PR DESCRIPTION
## Summary
- configure the production deploy workflow to install the SSH key on the runner
- replace the no-op ssh script with an rsync command so files are copied to the server
- exclude git metadata and env files while keeping remote files in sync via --delete

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d56defae8c832981bb22410a1561e4