### PR TITLE
Restore iOS safe-area status spacer

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -117,6 +117,7 @@
       `  --mm-mesh-background-dark: ${theme.gradients.mesh.dark};`,
       `  --mm-body-glow: ${theme.gradients.bodyGlow.light};`,
       `  --mm-body-glow-dark: ${theme.gradients.bodyGlow.dark};`,
+      `  --mm-statusbar-bg: ${theme.statusBar.light};`,
       `  --mm-card-surface: ${theme.surfaces.card.light};`,
       `  --mm-card-border: ${theme.surfaces.card.borderLight};`,
       `  --mm-tile-surface: ${theme.surfaces.tile.light};`,
@@ -179,6 +180,7 @@
       `  --mm-icon-danger-border: ${theme.icons.danger.borderDark};`,
       `  --mm-icon-danger-color: ${theme.icons.danger.colorDark};`,
       `  --mm-icon-danger-hover: ${theme.icons.danger.hoverDark};`,
+      `  --mm-statusbar-bg: ${theme.statusBar.dark};`,
       `  --mm-body-glow: ${theme.gradients.bodyGlow.dark};`,
       `}`,
     ];
@@ -205,6 +207,8 @@
     const primary = palette[500];
     const surfaceDeep = darken(base, 0.72);
     const surfaceGhost = lighten(base, 0.82);
+    const statusLight = toRgba(lighten(base, 0.86), 0.88);
+    const statusDark = toRgba(darken(base, 0.7), 0.85);
     const borderLight = lighten(base, 0.72);
     const borderDark = darken(base, 0.6);
     const baseBrightness = getBrightness(base);
@@ -288,6 +292,10 @@
             `radial-gradient(40% 40% at 88% 12%, ${toRgba(deep, 0.55)}, transparent 75%)`,
           ].join(', '),
         },
+      },
+      statusBar: {
+        light: statusLight,
+        dark: statusDark,
       },
       surfaces: {
         card: {

--- a/views/layout/header.php
+++ b/views/layout/header.php
@@ -207,6 +207,17 @@
       body.overlay-open {
         overflow: hidden;
       }
+      .status-bar-spacer {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: env(safe-area-inset-top, 0px);
+        background: linear-gradient(180deg, var(--mm-statusbar-bg, rgba(255,255,255,0.88)) 0%, rgba(255,255,255,0) 90%);
+        pointer-events: none;
+        z-index: 30;
+        transition: background 0.4s ease;
+      }
       @media (max-width: 640px) {
         body.overlay-open header {
           opacity: 0;
@@ -1057,6 +1068,7 @@
   <div class="pointer-events-none fixed inset-0 -z-10 opacity-60 mix-blend-normal">
     <div class="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(75,150,110,0.18),transparent_55%),radial-gradient(circle_at_80%_0%,rgba(50,100,75,0.22),transparent_65%)] dark:bg-[radial-gradient(circle_at_15%_15%,rgba(75,150,110,0.35),transparent_60%),radial-gradient(circle_at_85%_5%,rgba(18,36,29,0.55),transparent_70%)]"></div>
   </div>
+  <div class="status-bar-spacer" aria-hidden="true"></div>
   <?php
     $currentPath = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?? '/';
     $onboarding  = str_starts_with($currentPath, '/onboard');


### PR DESCRIPTION
## Summary
- add a fixed safe-area spacer that restores the iOS status bar padding and inherits the active theme
- expose status bar background tokens in the theme runtime so light and dark modes stay in sync

## Testing
- php -l views/layout/header.php

------
https://chatgpt.com/codex/tasks/task_e_68d577003c7c8329bd60faad909ff38f