### PR TITLE
Add advanced planner workflow for milestone budgeting

### DIFF
--- a/index.php
+++ b/index.php
@@ -472,6 +472,28 @@ switch ($path) {
         require __DIR__ . '/src/controllers/goals.php';
         goals_index($pdo);
         break;
+    case '/advanced-planner':
+        require_login();
+        require __DIR__ . '/src/controllers/advanced_planner.php';
+        if ($method === 'POST') {
+            advanced_planner_store($pdo);
+        }
+        advanced_planner_show($pdo);
+        break;
+    case '/advanced-planner/activate':
+        require_login();
+        require __DIR__ . '/src/controllers/advanced_planner.php';
+        if ($method === 'POST') {
+            advanced_planner_activate($pdo);
+        }
+        break;
+    case '/advanced-planner/delete':
+        require_login();
+        require __DIR__ . '/src/controllers/advanced_planner.php';
+        if ($method === 'POST') {
+            advanced_planner_delete($pdo);
+        }
+        break;
     case '/goals/add':
         require_login();
         require __DIR__ . '/src/controllers/goals.php';

--- a/migrations/011_advanced_planner.sql
+++ b/migrations/011_advanced_planner.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS advanced_plans (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  horizon_months INT NOT NULL CHECK (horizon_months IN (3,6,12)),
+  plan_start DATE NOT NULL,
+  plan_end DATE NOT NULL,
+  main_currency TEXT NOT NULL,
+  total_budget NUMERIC(18,2) DEFAULT 0,
+  monthly_income NUMERIC(18,2) DEFAULT 0,
+  monthly_commitments NUMERIC(18,2) DEFAULT 0,
+  monthly_discretionary NUMERIC(18,2) DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','active','archived')),
+  notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS advanced_plan_items (
+  id SERIAL PRIMARY KEY,
+  plan_id INT NOT NULL REFERENCES advanced_plans(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL CHECK (kind IN ('emergency','investment','loan','goal','custom')),
+  reference_id INT,
+  reference_label TEXT,
+  target_amount NUMERIC(18,2) NOT NULL,
+  current_amount NUMERIC(18,2) DEFAULT 0,
+  required_amount NUMERIC(18,2) NOT NULL,
+  monthly_allocation NUMERIC(18,2) NOT NULL,
+  priority INT DEFAULT 1,
+  sort_order INT DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'planned' CHECK (status IN ('planned','active','done','skipped')),
+  notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS advanced_plan_category_limits (
+  id SERIAL PRIMARY KEY,
+  plan_id INT NOT NULL REFERENCES advanced_plans(id) ON DELETE CASCADE,
+  category_id INT REFERENCES categories(id) ON DELETE CASCADE,
+  category_label TEXT,
+  suggested_limit NUMERIC(18,2) NOT NULL,
+  average_spent NUMERIC(18,2) DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(plan_id, category_id)
+);

--- a/src/controllers/advanced_planner.php
+++ b/src/controllers/advanced_planner.php
@@ -1,0 +1,532 @@
+<?php
+
+require_once __DIR__ . '/../helpers.php';
+require_once __DIR__ . '/../fx.php';
+
+function advanced_planner_show(PDO $pdo): void
+{
+    require_login();
+    $userId = uid();
+    $mainCurrency = fx_user_main($pdo, $userId) ?: 'HUF';
+
+    $startParam = trim($_GET['start'] ?? '');
+    $startMonth = $startParam !== ''
+        ? DateTimeImmutable::createFromFormat('Y-m', $startParam) ?: new DateTimeImmutable('first day of next month')
+        : new DateTimeImmutable('first day of next month');
+    $startMonth = $startMonth->setDate((int)$startMonth->format('Y'), (int)$startMonth->format('n'), 1);
+
+    $defaultHorizon = 3;
+
+    $incomeData = advanced_planner_collect_incomes($pdo, $userId, $mainCurrency, $startMonth);
+    $spendingCategories = advanced_planner_fetch_spending_categories($pdo, $userId);
+    $averages = advanced_planner_average_spending($pdo, $userId, $mainCurrency, $startMonth, $spendingCategories, 3);
+
+    $resources = advanced_planner_collect_resources($pdo, $userId, $mainCurrency);
+
+    $plansStmt = $pdo->prepare(
+        'SELECT * FROM advanced_plans WHERE user_id = ? ORDER BY (status = \'active\') DESC, plan_start DESC, id DESC'
+    );
+    $plansStmt->execute([$userId]);
+    $plans = $plansStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $requestedPlanId = isset($_GET['plan']) ? (int)$_GET['plan'] : null;
+    $currentPlan = null;
+    foreach ($plans as $plan) {
+        if ($requestedPlanId && (int)$plan['id'] === $requestedPlanId) {
+            $currentPlan = $plan;
+            break;
+        }
+        if ($currentPlan === null && $plan['status'] === 'active') {
+            $currentPlan = $plan;
+        }
+    }
+    if ($currentPlan === null && $plans) {
+        $currentPlan = $plans[0];
+    }
+
+    $planItems = [];
+    $planCategoryLimits = [];
+    if ($currentPlan) {
+        $itemStmt = $pdo->prepare(
+            'SELECT * FROM advanced_plan_items WHERE plan_id = ? ORDER BY priority ASC, sort_order ASC, id ASC'
+        );
+        $itemStmt->execute([(int)$currentPlan['id']]);
+        $planItems = $itemStmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $limitStmt = $pdo->prepare(
+            'SELECT * FROM advanced_plan_category_limits WHERE plan_id = ? ORDER BY category_label ASC'
+        );
+        $limitStmt->execute([(int)$currentPlan['id']]);
+        $planCategoryLimits = $limitStmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    view('advanced_planner/index', [
+        'plans' => $plans,
+        'currentPlan' => $currentPlan,
+        'planItems' => $planItems,
+        'planCategoryLimits' => $planCategoryLimits,
+        'mainCurrency' => $mainCurrency,
+        'startSuggestion' => $startMonth->format('Y-m'),
+        'defaultHorizon' => $defaultHorizon,
+        'incomeData' => $incomeData,
+        'spendingCategories' => $spendingCategories,
+        'averages' => $averages,
+        'resources' => $resources,
+    ]);
+}
+
+function advanced_planner_store(PDO $pdo): void
+{
+    verify_csrf();
+    require_login();
+    $userId = uid();
+    $mainCurrency = fx_user_main($pdo, $userId) ?: 'HUF';
+
+    $title = trim($_POST['title'] ?? '');
+    if ($title === '') {
+        $title = __('Advanced plan');
+    }
+
+    $horizon = (int)($_POST['horizon_months'] ?? 3);
+    if (!in_array($horizon, [3, 6, 12], true)) {
+        $horizon = 3;
+    }
+
+    $startMonthRaw = trim($_POST['start_month'] ?? '');
+    $startMonth = $startMonthRaw !== ''
+        ? DateTimeImmutable::createFromFormat('Y-m', $startMonthRaw) ?: new DateTimeImmutable('first day of next month')
+        : new DateTimeImmutable('first day of next month');
+    $startMonth = $startMonth->setDate((int)$startMonth->format('Y'), (int)$startMonth->format('n'), 1);
+    $planStart = $startMonth->format('Y-m-01');
+    $planEnd = $startMonth->modify('+' . $horizon . ' months')->modify('-1 day')->format('Y-m-d');
+
+    $notes = trim($_POST['notes'] ?? '');
+    $activate = !empty($_POST['activate']);
+
+    $labels = $_POST['item_label'] ?? [];
+    $types = $_POST['item_type'] ?? [];
+    $targets = $_POST['item_target'] ?? [];
+    $currents = $_POST['item_current'] ?? [];
+    $priorities = $_POST['item_priority'] ?? [];
+    $references = $_POST['item_reference'] ?? [];
+    $itemNotes = $_POST['item_notes'] ?? [];
+
+    $items = [];
+    $sortIndex = 0;
+    foreach ($labels as $idx => $labelRaw) {
+        $label = trim((string)$labelRaw);
+        $kind = isset($types[$idx]) ? strtolower((string)$types[$idx]) : 'custom';
+        if (!in_array($kind, ['emergency', 'investment', 'loan', 'goal', 'custom'], true)) {
+            $kind = 'custom';
+        }
+
+        $target = isset($targets[$idx]) ? max(0.0, (float)$targets[$idx]) : 0.0;
+        $current = isset($currents[$idx]) ? max(0.0, (float)$currents[$idx]) : 0.0;
+        $required = max(0.0, $target - $current);
+        if ($label === '' && $required <= 0) {
+            continue;
+        }
+        $monthly = $horizon > 0 ? round($required / $horizon, 2) : 0.0;
+
+        $priority = isset($priorities[$idx]) ? (int)$priorities[$idx] : ($sortIndex + 1);
+        $referenceId = isset($references[$idx]) && $references[$idx] !== '' ? (int)$references[$idx] : null;
+        $note = trim($itemNotes[$idx] ?? '');
+
+        $items[] = [
+            'label' => $label !== '' ? $label : __('Milestone :num', ['num' => $sortIndex + 1]),
+            'kind' => $kind,
+            'reference_id' => $referenceId,
+            'target' => round($target, 2),
+            'current' => round($current, 2),
+            'required' => round($required, 2),
+            'monthly' => $monthly,
+            'priority' => $priority,
+            'sort' => $sortIndex,
+            'notes' => $note,
+        ];
+        $sortIndex++;
+    }
+
+    $incomeData = advanced_planner_collect_incomes($pdo, $userId, $mainCurrency, $startMonth);
+    $monthlyIncome = (float)($incomeData['total'] ?? 0);
+
+    $spendingCategories = advanced_planner_fetch_spending_categories($pdo, $userId);
+    $averages = advanced_planner_average_spending($pdo, $userId, $mainCurrency, $startMonth, $spendingCategories, 3);
+
+    $totalCommitments = 0.0;
+    foreach ($items as $item) {
+        $totalCommitments += $item['monthly'];
+    }
+    $totalCommitments = round($totalCommitments, 2);
+
+    $monthlyDiscretionary = max(0.0, $monthlyIncome - $totalCommitments);
+
+    $categorySuggestions = [];
+    $totalAverage = 0.0;
+    foreach ($averages['categories'] as $cat) {
+        $totalAverage += (float)$cat['average'];
+    }
+    $scale = ($totalAverage > 0) ? ($monthlyDiscretionary / $totalAverage) : 0;
+    foreach ($averages['categories'] as $cat) {
+        $suggested = $totalAverage > 0
+            ? round($cat['average'] * min(max($scale, 0), 5), 2)
+            : (count($averages['categories']) ? round($monthlyDiscretionary / count($averages['categories']), 2) : 0.0);
+        $categorySuggestions[] = [
+            'category_id' => $cat['id'],
+            'label' => $cat['label'],
+            'average' => round($cat['average'], 2),
+            'suggested' => $suggested,
+        ];
+    }
+
+    $status = $activate ? 'active' : 'draft';
+
+    $pdo->beginTransaction();
+    try {
+        if ($activate) {
+            $pdo->prepare('UPDATE advanced_plans SET status = \'archived\', updated_at = NOW() WHERE user_id = ? AND status = \'active\'')
+                ->execute([$userId]);
+        }
+
+        $planStmt = $pdo->prepare(
+            'INSERT INTO advanced_plans (user_id, title, horizon_months, plan_start, plan_end, main_currency, total_budget, monthly_income, monthly_commitments, monthly_discretionary, status, notes) VALUES (?,?,?,?,?,?,?,?,?,?,?,?) RETURNING id'
+        );
+        $totalBudget = round($monthlyIncome * $horizon, 2);
+        $planStmt->execute([
+            $userId,
+            $title,
+            $horizon,
+            $planStart,
+            $planEnd,
+            $mainCurrency,
+            $totalBudget,
+            $monthlyIncome,
+            $totalCommitments,
+            $monthlyDiscretionary,
+            $status,
+            $notes,
+        ]);
+        $planId = (int)$planStmt->fetchColumn();
+
+        if ($items) {
+            $itemStmt = $pdo->prepare(
+                'INSERT INTO advanced_plan_items (plan_id, kind, reference_id, reference_label, target_amount, current_amount, required_amount, monthly_allocation, priority, sort_order, notes) VALUES (?,?,?,?,?,?,?,?,?,?,?)'
+            );
+            foreach ($items as $item) {
+                $itemStmt->execute([
+                    $planId,
+                    $item['kind'],
+                    $item['reference_id'],
+                    $item['label'],
+                    $item['target'],
+                    $item['current'],
+                    $item['required'],
+                    $item['monthly'],
+                    $item['priority'],
+                    $item['sort'],
+                    $item['notes'],
+                ]);
+            }
+        }
+
+        if ($categorySuggestions) {
+            $catStmt = $pdo->prepare(
+                'INSERT INTO advanced_plan_category_limits (plan_id, category_id, category_label, suggested_limit, average_spent) VALUES (?,?,?,?,?)'
+            );
+            foreach ($categorySuggestions as $cat) {
+                $catStmt->execute([
+                    $planId,
+                    $cat['category_id'],
+                    $cat['label'],
+                    $cat['suggested'],
+                    $cat['average'],
+                ]);
+            }
+        }
+
+        $pdo->commit();
+        $_SESSION['flash'] = $activate
+            ? __('Advanced plan activated.')
+            : __('Advanced plan saved as draft.');
+        redirect('/advanced-planner?plan=' . $planId);
+    } catch (Throwable $e) {
+        $pdo->rollBack();
+        error_log('Advanced planner save failed: ' . $e->getMessage());
+        $_SESSION['flash'] = __('Could not save the advanced plan.');
+        redirect('/advanced-planner');
+    }
+}
+
+function advanced_planner_activate(PDO $pdo): void
+{
+    verify_csrf();
+    require_login();
+    $userId = uid();
+    $planId = (int)($_POST['plan_id'] ?? 0);
+    if ($planId <= 0) {
+        redirect('/advanced-planner');
+    }
+
+    $pdo->beginTransaction();
+    try {
+        $planCheck = $pdo->prepare('SELECT id FROM advanced_plans WHERE id = ? AND user_id = ?');
+        $planCheck->execute([$planId, $userId]);
+        if (!$planCheck->fetch()) {
+            $pdo->rollBack();
+            $_SESSION['flash'] = __('Plan not found.');
+            redirect('/advanced-planner');
+        }
+
+        $pdo->prepare('UPDATE advanced_plans SET status = \'archived\', updated_at = NOW() WHERE user_id = ? AND status = \'active\'')
+            ->execute([$userId]);
+        $pdo->prepare('UPDATE advanced_plans SET status = \'active\', updated_at = NOW() WHERE id = ? AND user_id = ?')
+            ->execute([$planId, $userId]);
+        $pdo->commit();
+        $_SESSION['flash'] = __('Advanced plan is now live.');
+        redirect('/advanced-planner?plan=' . $planId);
+    } catch (Throwable $e) {
+        $pdo->rollBack();
+        error_log('Advanced planner activate failed: ' . $e->getMessage());
+        $_SESSION['flash'] = __('Could not activate the plan.');
+        redirect('/advanced-planner');
+    }
+}
+
+function advanced_planner_delete(PDO $pdo): void
+{
+    verify_csrf();
+    require_login();
+    $userId = uid();
+    $planId = (int)($_POST['plan_id'] ?? 0);
+    if ($planId <= 0) {
+        redirect('/advanced-planner');
+    }
+
+    $stmt = $pdo->prepare('DELETE FROM advanced_plans WHERE id = ? AND user_id = ?');
+    $stmt->execute([$planId, $userId]);
+    $_SESSION['flash'] = __('Plan deleted.');
+    redirect('/advanced-planner');
+}
+
+function advanced_planner_collect_incomes(PDO $pdo, int $userId, string $mainCurrency, DateTimeImmutable $startMonth): array
+{
+    $firstOfMonth = $startMonth->format('Y-m-01');
+    $year = (int)$startMonth->format('Y');
+    $month = (int)$startMonth->format('n');
+    $stmt = $pdo->prepare(
+        'SELECT label, amount, currency FROM basic_incomes WHERE user_id = ? AND valid_from <= ?::date AND (valid_to IS NULL OR valid_to >= ?::date)'
+    );
+    $stmt->execute([$userId, $firstOfMonth, $firstOfMonth]);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $total = 0.0;
+    $sources = [];
+    foreach ($rows as $row) {
+        $amount = (float)($row['amount'] ?? 0);
+        $currency = strtoupper($row['currency'] ?: $mainCurrency);
+        $converted = fx_convert_basic_income($pdo, $amount, $currency, $mainCurrency, $year, $month);
+        $total += $converted;
+        $sources[] = [
+            'label' => $row['label'] ?: __('Income'),
+            'amount' => round($amount, 2),
+            'currency' => $currency,
+            'converted' => round($converted, 2),
+        ];
+    }
+
+    return [
+        'total' => round($total, 2),
+        'sources' => $sources,
+        'month' => $firstOfMonth,
+    ];
+}
+
+function advanced_planner_fetch_spending_categories(PDO $pdo, int $userId): array
+{
+    $stmt = $pdo->prepare(
+        "SELECT id, label, COALESCE(NULLIF(color,''),'#6B7280') AS color FROM categories WHERE user_id = ? AND kind = 'spending' ORDER BY lower(label)"
+    );
+    $stmt->execute([$userId]);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+}
+
+function advanced_planner_average_spending(
+    PDO $pdo,
+    int $userId,
+    string $mainCurrency,
+    DateTimeImmutable $startMonth,
+    array $categories,
+    int $monthsBack
+): array {
+    $monthsBack = max(1, $monthsBack);
+    $windowStart = $startMonth->modify('-' . $monthsBack . ' months');
+    $windowStart = $windowStart->setDate((int)$windowStart->format('Y'), (int)$windowStart->format('n'), 1);
+    $windowEnd = $startMonth->modify('-1 day');
+
+    if ($windowEnd < $windowStart) {
+        $windowEnd = $windowStart;
+    }
+
+    $stmt = $pdo->prepare(
+        "SELECT t.category_id, t.amount, t.currency, t.occurred_on, t.amount_main, t.main_currency,
+                c.label AS cat_label, COALESCE(NULLIF(c.color,''),'#6B7280') AS cat_color
+           FROM transactions t
+           LEFT JOIN categories c ON c.id = t.category_id AND c.user_id = t.user_id
+          WHERE t.user_id = ? AND t.kind = 'spending' AND t.occurred_on BETWEEN ?::date AND ?::date"
+    );
+    $stmt->execute([$userId, $windowStart->format('Y-m-d'), $windowEnd->format('Y-m-d')]);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $totals = [];
+    foreach ($categories as $cat) {
+        $catId = (int)$cat['id'];
+        $totals[$catId] = [
+            'id' => $catId,
+            'label' => $cat['label'],
+            'color' => $cat['color'],
+            'total' => 0.0,
+        ];
+    }
+
+    foreach ($rows as $row) {
+        $catId = $row['category_id'] !== null ? (int)$row['category_id'] : null;
+        if ($catId === null || !isset($totals[$catId])) {
+            continue;
+        }
+        $amount = (float)$row['amount'];
+        $currency = strtoupper($row['currency'] ?: $mainCurrency);
+        $occurred = $row['occurred_on'];
+        $amtMain = null;
+        if ($row['amount_main'] !== null && $row['main_currency']) {
+            $storedMain = strtoupper((string)$row['main_currency']);
+            if ($storedMain === strtoupper($mainCurrency)) {
+                $amtMain = (float)$row['amount_main'];
+            } else {
+                $rate = fx_rate_from_to($pdo, $storedMain, $mainCurrency, $occurred);
+                if ($rate !== null) {
+                    $amtMain = round((float)$row['amount_main'] * $rate, 2);
+                }
+            }
+        }
+        if ($amtMain === null) {
+            $rate = fx_rate_from_to($pdo, $currency, $mainCurrency, $occurred);
+            $amtMain = $rate !== null ? round($amount * $rate, 2) : $amount;
+        }
+        $totals[$catId]['total'] += $amtMain;
+    }
+
+    $period = new DatePeriod(
+        $windowStart,
+        new DateInterval('P1M'),
+        $startMonth
+    );
+    $monthsCount = 0;
+    foreach ($period as $_) {
+        $monthsCount++;
+    }
+    $monthsCount = max(1, $monthsCount);
+
+    foreach ($totals as &$cat) {
+        $cat['total'] = round($cat['total'], 2);
+        $cat['average'] = round($cat['total'] / $monthsCount, 2);
+    }
+    unset($cat);
+
+    return [
+        'categories' => array_values($totals),
+        'months' => $monthsCount,
+        'window_start' => $windowStart->format('Y-m-d'),
+        'window_end' => $windowEnd->format('Y-m-d'),
+    ];
+}
+
+function advanced_planner_collect_resources(PDO $pdo, int $userId, string $mainCurrency): array
+{
+    $today = (new DateTimeImmutable('today'))->format('Y-m-d');
+
+    $emergencyStmt = $pdo->prepare('SELECT target_amount, total, currency FROM emergency_fund WHERE user_id = ?');
+    $emergencyStmt->execute([$userId]);
+    $emergency = $emergencyStmt->fetch(PDO::FETCH_ASSOC);
+    $emergencyData = null;
+    if ($emergency) {
+        $target = (float)($emergency['target_amount'] ?? 0);
+        $current = (float)($emergency['total'] ?? 0);
+        $currency = strtoupper($emergency['currency'] ?: $mainCurrency);
+        $remaining = max(0.0, $target - $current);
+        $remainingMain = advanced_planner_convert_to_main($pdo, $remaining, $currency, $mainCurrency, $today);
+        $emergencyData = [
+            'label' => __('Emergency fund'),
+            'target' => round($target, 2),
+            'current' => round($current, 2),
+            'currency' => $currency,
+            'remaining' => round($remaining, 2),
+            'remaining_main' => round($remainingMain, 2),
+        ];
+    }
+
+    $goalStmt = $pdo->prepare('SELECT id, title, target_amount, current_amount, currency, status FROM goals WHERE user_id = ? ORDER BY lower(title)');
+    $goalStmt->execute([$userId]);
+    $goals = [];
+    foreach ($goalStmt as $row) {
+        $target = (float)($row['target_amount'] ?? 0);
+        $current = (float)($row['current_amount'] ?? 0);
+        $currency = strtoupper($row['currency'] ?: $mainCurrency);
+        $remaining = max(0.0, $target - $current);
+        if ($remaining <= 0) {
+            continue;
+        }
+        $remainingMain = advanced_planner_convert_to_main($pdo, $remaining, $currency, $mainCurrency, $today);
+        $goals[] = [
+            'id' => (int)$row['id'],
+            'label' => $row['title'] ?: __('Goal'),
+            'currency' => $currency,
+            'remaining' => round($remaining, 2),
+            'remaining_main' => round($remainingMain, 2),
+            'status' => $row['status'],
+        ];
+    }
+
+    $loanStmt = $pdo->prepare('SELECT id, name, balance, currency FROM loans WHERE user_id = ? ORDER BY lower(name)');
+    $loanStmt->execute([$userId]);
+    $loans = [];
+    foreach ($loanStmt as $row) {
+        $balance = (float)($row['balance'] ?? 0);
+        if ($balance <= 0) {
+            continue;
+        }
+        $currency = strtoupper($row['currency'] ?: $mainCurrency);
+        $balanceMain = advanced_planner_convert_to_main($pdo, $balance, $currency, $mainCurrency, $today);
+        $loans[] = [
+            'id' => (int)$row['id'],
+            'label' => $row['name'] ?: __('Loan'),
+            'currency' => $currency,
+            'balance' => round($balance, 2),
+            'balance_main' => round($balanceMain, 2),
+        ];
+    }
+
+    return [
+        'emergency' => $emergencyData,
+        'goals' => $goals,
+        'loans' => $loans,
+    ];
+}
+
+function advanced_planner_convert_to_main(
+    PDO $pdo,
+    float $amount,
+    string $fromCurrency,
+    string $mainCurrency,
+    string $date
+): float {
+    $fromCurrency = strtoupper($fromCurrency ?: $mainCurrency);
+    $mainCurrency = strtoupper($mainCurrency ?: $fromCurrency);
+    if ($fromCurrency === $mainCurrency) {
+        return round($amount, 2);
+    }
+    $rate = fx_rate_from_to($pdo, $fromCurrency, $mainCurrency, $date);
+    if ($rate === null) {
+        return round($amount, 2);
+    }
+    return round($amount * $rate, 2);
+}

--- a/src/controllers/more.php
+++ b/src/controllers/more.php
@@ -45,6 +45,12 @@ function more_show(PDO $pdo): void
                     'icon' => 'goal',
                 ],
                 [
+                    'label' => __('Advanced planner'),
+                    'description' => __('Map out milestones, budgets, and an order of attack for the months ahead.'),
+                    'href' => '/advanced-planner',
+                    'icon' => 'route',
+                ],
+                [
                     'label' => __('Loans'),
                     'description' => __('Manage debts, schedules, and payoff progress.'),
                     'href' => '/loans',

--- a/views/advanced_planner/index.php
+++ b/views/advanced_planner/index.php
@@ -1,0 +1,651 @@
+<?php
+/** @var array $plans */
+/** @var array|null $currentPlan */
+/** @var array $planItems */
+/** @var array $planCategoryLimits */
+/** @var string $mainCurrency */
+/** @var string $startSuggestion */
+/** @var int $defaultHorizon */
+/** @var array $incomeData */
+/** @var array $spendingCategories */
+/** @var array $averages */
+/** @var array $resources */
+?>
+
+<section class="card">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-semibold text-slate-900 dark:text-white"><?= __('Advanced planner') ?></h1>
+      <p class="mt-1 max-w-2xl text-sm text-slate-600 dark:text-slate-300/80">
+        <?= __('Design a focused financial roadmap for the next quarter, half-year, or full year. Capture milestones, estimate monthly allocations, and tune your category budgets before making the plan live.') ?>
+      </p>
+    </div>
+    <?php if (!empty($plans)): ?>
+      <div class="rounded-2xl border border-white/70 bg-white/80 px-4 py-3 text-sm shadow-sm backdrop-blur dark:border-slate-800/60 dark:bg-slate-900/60">
+        <div class="font-semibold text-slate-800 dark:text-slate-100"><?= __('Saved plans') ?></div>
+        <div class="mt-1 text-slate-500 dark:text-slate-400">
+          <?= __(':count plans total', ['count' => count($plans)]) ?>
+        </div>
+      </div>
+    <?php endif; ?>
+  </div>
+  <?php if (!empty($_SESSION['flash'])): ?>
+    <p class="mt-4 rounded-2xl bg-brand-50/70 px-4 py-3 text-sm text-brand-700 shadow-sm dark:bg-brand-500/15 dark:text-brand-100">
+      <?= htmlspecialchars($_SESSION['flash'], ENT_QUOTES) ?>
+      <?php unset($_SESSION['flash']); ?>
+    </p>
+  <?php endif; ?>
+</section>
+
+<section class="mt-6 card">
+  <div class="card-kicker"><?= __('Baseline insights') ?></div>
+  <h2 class="card-title">
+    <?= __('Starting point for :month', ['month' => date('F Y', strtotime($incomeData['month'] ?? ($startSuggestion . '-01')))]) ?>
+  </h2>
+  <div class="mt-6 grid gap-6 lg:grid-cols-2">
+    <div class="rounded-3xl border border-white/60 bg-white/70 p-5 shadow-sm backdrop-blur-sm dark:border-slate-800/60 dark:bg-slate-900/60">
+      <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"><?= __('Reliable income') ?></h3>
+      <div class="mt-3 text-2xl font-semibold text-slate-900 dark:text-white">
+        <?= moneyfmt($incomeData['total'] ?? 0, $mainCurrency) ?>
+      </div>
+      <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+        <?= __('Active basic incomes converted to your main currency.') ?>
+      </p>
+      <ul class="mt-4 space-y-2 text-sm">
+        <?php if (!empty($incomeData['sources'])): ?>
+          <?php foreach ($incomeData['sources'] as $source): ?>
+            <li class="flex items-start justify-between gap-3 rounded-2xl border border-white/50 bg-white/60 px-3 py-2 text-slate-600 shadow-sm backdrop-blur-sm dark:border-slate-800/70 dark:bg-slate-900/50 dark:text-slate-300">
+              <span class="font-medium text-slate-700 dark:text-slate-200"><?= htmlspecialchars($source['label'], ENT_QUOTES) ?></span>
+              <span class="text-right">
+                <span class="block text-xs text-slate-400 dark:text-slate-500"><?= moneyfmt($source['amount'], $source['currency']) ?></span>
+                <span class="block font-semibold text-slate-700 dark:text-slate-200"><?= moneyfmt($source['converted'], $mainCurrency) ?></span>
+              </span>
+            </li>
+          <?php endforeach; ?>
+        <?php else: ?>
+          <li class="rounded-2xl border border-dashed border-slate-300/60 px-3 py-3 text-slate-500 dark:border-slate-700 dark:text-slate-400">
+            <?= __('No recurring incomes captured yet. Add them under Settings → Basic incomes for more precise planning.') ?>
+          </li>
+        <?php endif; ?>
+      </ul>
+    </div>
+    <div class="rounded-3xl border border-white/60 bg-white/70 p-5 shadow-sm backdrop-blur-sm dark:border-slate-800/60 dark:bg-slate-900/60">
+      <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"><?= __('Recent spending averages') ?></h3>
+      <p class="text-sm text-slate-500 dark:text-slate-400">
+        <?= __('Based on :months months of history (:from → :to).', [
+          'months' => $averages['months'] ?? 0,
+          'from' => date('M Y', strtotime($averages['window_start'] ?? $startSuggestion . '-01')),
+          'to' => date('M Y', strtotime($averages['window_end'] ?? $startSuggestion . '-01')),
+        ]) ?>
+      </p>
+      <div class="mt-4 grid gap-2 sm:grid-cols-2">
+        <?php if (!empty($averages['categories'])): ?>
+          <?php foreach ($averages['categories'] as $cat): ?>
+            <div class="rounded-2xl border border-white/50 bg-white/60 px-3 py-2 shadow-sm backdrop-blur-sm dark:border-slate-800/70 dark:bg-slate-900/50">
+              <div class="flex items-center justify-between">
+                <span class="text-sm font-medium text-slate-700 dark:text-slate-100"><?= htmlspecialchars($cat['label'], ENT_QUOTES) ?></span>
+                <span class="inline-flex h-2.5 w-2.5 rounded-full" style="background-color: <?= htmlspecialchars($cat['color'], ENT_QUOTES) ?>"></span>
+              </div>
+              <div class="mt-1 text-xs text-slate-500 dark:text-slate-400"><?= __('Average') ?></div>
+              <div class="text-base font-semibold text-slate-900 dark:text-white"><?= moneyfmt($cat['average'], $mainCurrency) ?></div>
+            </div>
+          <?php endforeach; ?>
+        <?php else: ?>
+          <div class="rounded-2xl border border-dashed border-slate-300/60 px-3 py-3 text-slate-500 dark:border-slate-700 dark:text-slate-400">
+            <?= __('No spending history yet. Once you record transactions we will surface category averages here.') ?>
+          </div>
+        <?php endif; ?>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="mt-6 card">
+  <div class="card-kicker"><?= __('Draft a new plan') ?></div>
+  <h2 class="card-title"><?= __('Build your timeline') ?></h2>
+  <form class="mt-6 space-y-6" method="post" action="/advanced-planner">
+    <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+    <div class="grid gap-4 md:grid-cols-2">
+      <label class="block">
+        <span class="label"><?= __('Plan title') ?></span>
+        <input class="input" name="title" placeholder="<?= __('Quarterly wealth sprint') ?>" />
+      </label>
+      <label class="block">
+        <span class="label"><?= __('Start month') ?></span>
+        <input class="input" type="month" name="start_month" value="<?= htmlspecialchars($startSuggestion, ENT_QUOTES) ?>" required />
+      </label>
+      <label class="block">
+        <span class="label"><?= __('Time horizon') ?></span>
+        <select class="select" name="horizon_months" data-horizon-selector>
+          <option value="3" <?= $defaultHorizon === 3 ? 'selected' : '' ?>><?= __('Next 3 months (quarter)') ?></option>
+          <option value="6"><?= __('Next 6 months (half-year)') ?></option>
+          <option value="12"><?= __('Next 12 months (full year)') ?></option>
+        </select>
+      </label>
+      <label class="block">
+        <span class="label"><?= __('Notes (optional)') ?></span>
+        <textarea class="textarea" name="notes" rows="3" placeholder="<?= __('Add context, assumptions, or reminders for future you.') ?>"></textarea>
+      </label>
+    </div>
+
+    <div>
+      <div class="flex items-center justify-between gap-3">
+        <div>
+          <h3 class="text-lg font-semibold text-slate-900 dark:text-white"><?= __('Milestones & funding targets') ?></h3>
+          <p class="text-sm text-slate-500 dark:text-slate-400">
+            <?= __('Each milestone represents a goal, loan payoff, investment, or custom initiative to fund within the horizon.') ?>
+          </p>
+        </div>
+        <button type="button" class="btn btn-muted" data-add-item>
+          <i data-lucide="plus" class="h-4 w-4"></i>
+          <span><?= __('Add milestone') ?></span>
+        </button>
+      </div>
+      <div class="mt-4 space-y-3" data-items-container>
+        <p class="rounded-2xl border border-dashed border-slate-300/70 px-4 py-3 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400" data-empty-state>
+          <?= __('No milestones yet. Add them manually or pull in suggestions below.') ?>
+        </p>
+      </div>
+    </div>
+
+    <?php if (!empty($resources['emergency']) || !empty($resources['goals']) || !empty($resources['loans'])): ?>
+      <div class="rounded-3xl border border-white/60 bg-white/60 p-4 shadow-sm backdrop-blur dark:border-slate-800/60 dark:bg-slate-900/50">
+        <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"><?= __('Quick adds from your data') ?></h3>
+        <div class="mt-3 grid gap-3 lg:grid-cols-3">
+          <?php if (!empty($resources['emergency'])): $ef = $resources['emergency']; ?>
+            <div class="panel p-4">
+              <div class="text-sm font-semibold text-slate-700 dark:text-slate-100"><?= __('Emergency fund gap') ?></div>
+              <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                <?= __('Need :amount to reach the target.', ['amount' => moneyfmt($ef['remaining'], $ef['currency'])]) ?>
+              </p>
+              <button
+                type="button"
+                class="btn btn-primary mt-3 w-full"
+                data-quick-add
+                data-kind="emergency"
+                data-label="<?= htmlspecialchars(__('Collect full emergency fund'), ENT_QUOTES) ?>"
+                data-target="<?= htmlspecialchars($ef['remaining_main'], ENT_QUOTES) ?>"
+                data-current="0"
+                data-reference=""
+                data-notes="<?= htmlspecialchars(__('Target gap: :amount', ['amount' => moneyfmt($ef['remaining'], $ef['currency'])]), ENT_QUOTES) ?>"
+              >
+                <?= __('Add to plan') ?>
+              </button>
+            </div>
+          <?php endif; ?>
+
+          <?php if (!empty($resources['goals'])): ?>
+            <div class="panel p-4">
+              <div class="text-sm font-semibold text-slate-700 dark:text-slate-100"><?= __('Goals nearing completion') ?></div>
+              <ul class="mt-2 space-y-2 text-sm">
+                <?php foreach ($resources['goals'] as $goal): ?>
+                  <li class="rounded-2xl border border-white/60 bg-white/70 p-3 shadow-sm backdrop-blur-sm dark:border-slate-800/60 dark:bg-slate-900/60">
+                    <div class="font-medium text-slate-700 dark:text-slate-100"><?= htmlspecialchars($goal['label'], ENT_QUOTES) ?></div>
+                    <div class="text-xs text-slate-500 dark:text-slate-400">
+                      <?= __('Need :amount', ['amount' => moneyfmt($goal['remaining'], $goal['currency'])]) ?>
+                    </div>
+                    <button
+                      type="button"
+                      class="btn btn-muted mt-2 w-full"
+                      data-quick-add
+                      data-kind="goal"
+                      data-label="<?= htmlspecialchars(__('Finish goal: :name', ['name' => $goal['label']]), ENT_QUOTES) ?>"
+                      data-target="<?= htmlspecialchars($goal['remaining_main'], ENT_QUOTES) ?>"
+                      data-current="0"
+                      data-reference="<?= (int)$goal['id'] ?>"
+                      data-notes="<?= htmlspecialchars(__('Remaining native amount: :amount', ['amount' => moneyfmt($goal['remaining'], $goal['currency'])]), ENT_QUOTES) ?>"
+                    >
+                      <?= __('Add') ?>
+                    </button>
+                  </li>
+                <?php endforeach; ?>
+              </ul>
+            </div>
+          <?php endif; ?>
+
+          <?php if (!empty($resources['loans'])): ?>
+            <div class="panel p-4">
+              <div class="text-sm font-semibold text-slate-700 dark:text-slate-100"><?= __('Loans to eliminate') ?></div>
+              <ul class="mt-2 space-y-2 text-sm">
+                <?php foreach ($resources['loans'] as $loan): ?>
+                  <li class="rounded-2xl border border-white/60 bg-white/70 p-3 shadow-sm backdrop-blur-sm dark:border-slate-800/60 dark:bg-slate-900/60">
+                    <div class="font-medium text-slate-700 dark:text-slate-100"><?= htmlspecialchars($loan['label'], ENT_QUOTES) ?></div>
+                    <div class="text-xs text-slate-500 dark:text-slate-400">
+                      <?= __('Balance :amount', ['amount' => moneyfmt($loan['balance'], $loan['currency'])]) ?>
+                    </div>
+                    <button
+                      type="button"
+                      class="btn btn-muted mt-2 w-full"
+                      data-quick-add
+                      data-kind="loan"
+                      data-label="<?= htmlspecialchars(__('Pay off loan: :name', ['name' => $loan['label']]), ENT_QUOTES) ?>"
+                      data-target="<?= htmlspecialchars($loan['balance_main'], ENT_QUOTES) ?>"
+                      data-current="0"
+                      data-reference="<?= (int)$loan['id'] ?>"
+                      data-notes="<?= htmlspecialchars(__('Outstanding native balance: :amount', ['amount' => moneyfmt($loan['balance'], $loan['currency'])]), ENT_QUOTES) ?>"
+                    >
+                      <?= __('Add') ?>
+                    </button>
+                  </li>
+                <?php endforeach; ?>
+              </ul>
+            </div>
+          <?php endif; ?>
+        </div>
+      </div>
+    <?php endif; ?>
+
+    <div class="rounded-3xl border border-white/70 bg-white/70 p-4 shadow-sm backdrop-blur dark:border-slate-800/60 dark:bg-slate-900/50">
+      <div class="flex items-center justify-between gap-3">
+        <div>
+          <h3 class="text-lg font-semibold text-slate-900 dark:text-white"><?= __('Category budget suggestions') ?></h3>
+          <p class="text-sm text-slate-500 dark:text-slate-400">
+            <?= __('We scale your recent spending averages to fit the projected leftover cash once milestones are funded.') ?>
+          </p>
+        </div>
+        <span class="rounded-full border border-white/70 bg-white/80 px-4 py-1 text-sm font-medium text-slate-600 shadow-sm dark:border-slate-800/60 dark:bg-slate-900/60 dark:text-slate-300" data-leftover-preview>
+          <?= __('Leftover estimate: :amount/month', ['amount' => moneyfmt(0, $mainCurrency)]) ?>
+        </span>
+      </div>
+      <div class="mt-4 overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead>
+            <tr class="border-b border-white/60 text-left text-xs uppercase tracking-wide text-slate-500 dark:border-slate-800/60 dark:text-slate-400">
+              <th class="py-2 pr-3"><?= __('Category') ?></th>
+              <th class="py-2 pr-3"><?= __('Avg / month') ?></th>
+              <th class="py-2 pr-3"><?= __('Suggested limit') ?></th>
+            </tr>
+          </thead>
+          <tbody data-category-suggestions>
+            <?php if (!empty($averages['categories'])): ?>
+              <?php foreach ($averages['categories'] as $cat): ?>
+                <tr class="border-b border-white/50 dark:border-slate-800/50">
+                  <td class="py-2 pr-3">
+                    <div class="flex items-center gap-2">
+                      <span class="inline-flex h-2.5 w-2.5 rounded-full" style="background-color: <?= htmlspecialchars($cat['color'], ENT_QUOTES) ?>"></span>
+                      <span class="font-medium text-slate-700 dark:text-slate-100"><?= htmlspecialchars($cat['label'], ENT_QUOTES) ?></span>
+                    </div>
+                    <input type="hidden" name="category_id[]" value="<?= (int)$cat['id'] ?>" />
+                    <input type="hidden" name="category_label[]" value="<?= htmlspecialchars($cat['label'], ENT_QUOTES) ?>" />
+                    <input type="hidden" name="category_average[]" value="<?= htmlspecialchars($cat['average'], ENT_QUOTES) ?>" data-category-average />
+                    <input type="hidden" name="category_suggested[]" value="<?= htmlspecialchars($cat['average'], ENT_QUOTES) ?>" data-category-suggested />
+                  </td>
+                  <td class="py-2 pr-3 text-slate-600 dark:text-slate-300" data-category-average-display>
+                    <?= moneyfmt($cat['average'], $mainCurrency) ?>
+                  </td>
+                  <td class="py-2 pr-3 font-semibold text-slate-900 dark:text-white" data-category-suggested-display>
+                    <?= moneyfmt($cat['average'], $mainCurrency) ?>
+                  </td>
+                </tr>
+              <?php endforeach; ?>
+            <?php else: ?>
+              <tr>
+                <td colspan="3" class="py-4 text-center text-slate-500 dark:text-slate-400">
+                  <?= __('We will auto-fill suggestions after you log some spending categories.') ?>
+                </td>
+              </tr>
+            <?php endif; ?>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-3 rounded-3xl border border-white/70 bg-white/80 px-4 py-4 shadow-sm backdrop-blur dark:border-slate-800/60 dark:bg-slate-900/60 sm:flex-row sm:items-center sm:justify-between">
+      <label class="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+        <input type="checkbox" name="activate" value="1" class="checkbox" />
+        <span><?= __('Make this plan live immediately') ?></span>
+      </label>
+      <button type="submit" class="btn btn-primary">
+        <i data-lucide="sparkles" class="h-4 w-4"></i>
+        <span><?= __('Generate plan') ?></span>
+      </button>
+    </div>
+  </form>
+</section>
+
+<?php if ($currentPlan): ?>
+  <section class="mt-6 card">
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <div class="card-kicker"><?= __('Current plan overview') ?></div>
+        <h2 class="card-title">
+          <?= htmlspecialchars($currentPlan['title'] ?? __('Advanced plan'), ENT_QUOTES) ?>
+        </h2>
+        <p class="text-sm text-slate-500 dark:text-slate-400">
+          <?= __('Status: :status · Horizon: :months months', [
+            'status' => ucfirst($currentPlan['status']),
+            'months' => (int)$currentPlan['horizon_months'],
+          ]) ?>
+        </p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <span class="rounded-full border border-white/70 bg-white/80 px-4 py-1 text-sm text-slate-600 dark:border-slate-800/60 dark:bg-slate-900/60 dark:text-slate-300">
+          <?= __('Start :start', ['start' => date('M Y', strtotime($currentPlan['plan_start']))]) ?>
+        </span>
+        <span class="rounded-full border border-white/70 bg-white/80 px-4 py-1 text-sm text-slate-600 dark:border-slate-800/60 dark:bg-slate-900/60 dark:text-slate-300">
+          <?= __('End :end', ['end' => date('M Y', strtotime($currentPlan['plan_end']))]) ?>
+        </span>
+      </div>
+    </div>
+
+    <div class="mt-6 grid gap-4 sm:grid-cols-3">
+      <div class="panel p-4 text-sm">
+        <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400"><?= __('Monthly income') ?></div>
+        <div class="mt-1 text-2xl font-semibold text-slate-900 dark:text-white"><?= moneyfmt($currentPlan['monthly_income'], $currentPlan['main_currency']) ?></div>
+      </div>
+      <div class="panel p-4 text-sm">
+        <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400"><?= __('Milestone funding') ?></div>
+        <div class="mt-1 text-2xl font-semibold text-slate-900 dark:text-white"><?= moneyfmt($currentPlan['monthly_commitments'], $currentPlan['main_currency']) ?></div>
+      </div>
+      <div class="panel p-4 text-sm">
+        <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400"><?= __('Leftover for spending') ?></div>
+        <div class="mt-1 text-2xl font-semibold text-slate-900 dark:text-white"><?= moneyfmt($currentPlan['monthly_discretionary'], $currentPlan['main_currency']) ?></div>
+      </div>
+    </div>
+
+    <div class="mt-6">
+      <h3 class="text-lg font-semibold text-slate-900 dark:text-white"><?= __('Milestone order') ?></h3>
+      <div class="mt-3 overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead>
+            <tr class="border-b border-white/60 text-left text-xs uppercase tracking-wide text-slate-500 dark:border-slate-800/60 dark:text-slate-400">
+              <th class="py-2 pr-3"><?= __('Priority') ?></th>
+              <th class="py-2 pr-3"><?= __('Milestone') ?></th>
+              <th class="py-2 pr-3"><?= __('Target') ?></th>
+              <th class="py-2 pr-3"><?= __('Monthly allocation') ?></th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php foreach ($planItems as $item): ?>
+              <tr class="border-b border-white/50 dark:border-slate-800/50">
+                <td class="py-2 pr-3 text-slate-500 dark:text-slate-400">#<?= (int)$item['priority'] ?></td>
+                <td class="py-2 pr-3">
+                  <div class="font-medium text-slate-700 dark:text-slate-100"><?= htmlspecialchars($item['reference_label'], ENT_QUOTES) ?></div>
+                  <?php if (!empty($item['notes'])): ?>
+                    <div class="text-xs text-slate-500 dark:text-slate-400"><?= nl2br(htmlspecialchars($item['notes'], ENT_QUOTES)) ?></div>
+                  <?php endif; ?>
+                </td>
+                <td class="py-2 pr-3 text-slate-600 dark:text-slate-300"><?= moneyfmt($item['required_amount'], $currentPlan['main_currency']) ?></td>
+                <td class="py-2 pr-3 font-semibold text-slate-900 dark:text-white"><?= moneyfmt($item['monthly_allocation'], $currentPlan['main_currency']) ?></td>
+              </tr>
+            <?php endforeach; if (!$planItems): ?>
+              <tr>
+                <td colspan="4" class="py-4 text-center text-slate-500 dark:text-slate-400"><?= __('No milestones were captured for this plan.') ?></td>
+              </tr>
+            <?php endif; ?>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="mt-6">
+      <h3 class="text-lg font-semibold text-slate-900 dark:text-white"><?= __('Suggested category limits') ?></h3>
+      <div class="mt-3 overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead>
+            <tr class="border-b border-white/60 text-left text-xs uppercase tracking-wide text-slate-500 dark:border-slate-800/60 dark:text-slate-400">
+              <th class="py-2 pr-3"><?= __('Category') ?></th>
+              <th class="py-2 pr-3"><?= __('Avg / month') ?></th>
+              <th class="py-2 pr-3"><?= __('Suggested limit') ?></th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php foreach ($planCategoryLimits as $cat): ?>
+              <tr class="border-b border-white/50 dark:border-slate-800/50">
+                <td class="py-2 pr-3 font-medium text-slate-700 dark:text-slate-100"><?= htmlspecialchars($cat['category_label'], ENT_QUOTES) ?></td>
+                <td class="py-2 pr-3 text-slate-600 dark:text-slate-300"><?= moneyfmt($cat['average_spent'], $currentPlan['main_currency']) ?></td>
+                <td class="py-2 pr-3 font-semibold text-slate-900 dark:text-white"><?= moneyfmt($cat['suggested_limit'], $currentPlan['main_currency']) ?></td>
+              </tr>
+            <?php endforeach; if (!$planCategoryLimits): ?>
+              <tr>
+                <td colspan="3" class="py-4 text-center text-slate-500 dark:text-slate-400"><?= __('No category limits were recorded for this plan.') ?></td>
+              </tr>
+            <?php endif; ?>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div class="text-sm text-slate-500 dark:text-slate-400">
+        <?= __('Switch between saved plans using the selector below or delete ones you no longer need.') ?>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <?php if ($currentPlan['status'] !== 'active'): ?>
+          <form method="post" action="/advanced-planner/activate" class="inline">
+            <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+            <input type="hidden" name="plan_id" value="<?= (int)$currentPlan['id'] ?>" />
+            <button type="submit" class="btn btn-primary">
+              <i data-lucide="rocket" class="h-4 w-4"></i>
+              <span><?= __('Make live') ?></span>
+            </button>
+          </form>
+        <?php endif; ?>
+        <form method="post" action="/advanced-planner/delete" onsubmit="return confirm('<?= __('Delete this plan?') ?>');" class="inline">
+          <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+          <input type="hidden" name="plan_id" value="<?= (int)$currentPlan['id'] ?>" />
+          <button type="submit" class="btn btn-muted">
+            <i data-lucide="trash" class="h-4 w-4"></i>
+            <span><?= __('Delete') ?></span>
+          </button>
+        </form>
+      </div>
+    </div>
+  </section>
+<?php endif; ?>
+
+<?php if (!empty($plans)): ?>
+  <section class="mt-6 card">
+    <div class="card-kicker"><?= __('Saved plans') ?></div>
+    <h2 class="card-title"><?= __('Review or jump to an older plan') ?></h2>
+    <div class="mt-4 grid gap-3 md:grid-cols-2">
+      <?php foreach ($plans as $plan): ?>
+        <a href="<?= '/advanced-planner?plan=' . (int)$plan['id'] ?>" class="panel block p-4 transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:-translate-y-0.5 focus-visible:shadow-lg">
+          <div class="flex items-center justify-between">
+            <div>
+              <div class="text-sm font-semibold text-slate-800 dark:text-slate-100"><?= htmlspecialchars($plan['title'], ENT_QUOTES) ?></div>
+              <div class="text-xs text-slate-500 dark:text-slate-400">
+                <?= __('Horizon: :months months', ['months' => (int)$plan['horizon_months']]) ?> · <?= __('Status: :status', ['status' => ucfirst($plan['status'])]) ?>
+              </div>
+            </div>
+            <?php if ($plan['status'] === 'active'): ?>
+              <span class="rounded-full bg-brand-500/20 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-brand-700 dark:bg-brand-500/30 dark:text-brand-100">
+                <?= __('Live') ?>
+              </span>
+            <?php endif; ?>
+          </div>
+          <div class="mt-3 text-sm text-slate-500 dark:text-slate-400">
+            <?= __('Start :start · End :end', [
+              'start' => date('M Y', strtotime($plan['plan_start'])),
+              'end' => date('M Y', strtotime($plan['plan_end'])),
+            ]) ?>
+          </div>
+        </a>
+      <?php endforeach; ?>
+    </div>
+  </section>
+<?php endif; ?>
+
+<template id="planner-item-template">
+  <div class="panel p-4" data-item>
+    <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+      <div class="grid flex-1 gap-3 md:grid-cols-12">
+        <label class="md:col-span-5">
+          <span class="label"><?= __('Label') ?></span>
+          <input class="input" name="item_label[]" placeholder="<?= __('Build EF to 3 months') ?>" required />
+        </label>
+        <label class="md:col-span-3">
+          <span class="label"><?= __('Type') ?></span>
+          <select class="select" name="item_type[]">
+            <option value="emergency"><?= __('Emergency fund') ?></option>
+            <option value="investment"><?= __('Investment') ?></option>
+            <option value="loan"><?= __('Loan payoff') ?></option>
+            <option value="goal"><?= __('Goal') ?></option>
+            <option value="custom" selected><?= __('Custom') ?></option>
+          </select>
+        </label>
+        <label class="md:col-span-2">
+          <span class="label"><?= __('Target (main currency)') ?></span>
+          <input class="input" type="number" step="0.01" min="0" name="item_target[]" value="0" data-target-input />
+        </label>
+        <label class="md:col-span-2">
+          <span class="label"><?= __('Already set aside') ?></span>
+          <input class="input" type="number" step="0.01" min="0" name="item_current[]" value="0" data-current-input />
+        </label>
+        <label class="md:col-span-2">
+          <span class="label"><?= __('Priority order') ?></span>
+          <input class="input" type="number" min="1" step="1" name="item_priority[]" value="1" />
+        </label>
+        <label class="md:col-span-12">
+          <span class="label"><?= __('Notes (optional)') ?></span>
+          <textarea class="textarea" name="item_notes[]" rows="2" placeholder="<?= __('Add colour, dates, or reference links.') ?>"></textarea>
+        </label>
+        <input type="hidden" name="item_reference[]" value="" />
+      </div>
+      <div class="flex flex-col items-end gap-2 md:w-40">
+        <div class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400"><?= __('Monthly estimate') ?></div>
+        <div class="text-lg font-semibold text-slate-900 dark:text-white" data-monthly-output><?= moneyfmt(0, $mainCurrency) ?></div>
+        <button type="button" class="btn btn-muted" data-remove-item>
+          <i data-lucide="trash-2" class="h-4 w-4"></i>
+          <span><?= __('Remove') ?></span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const container = document.querySelector('[data-items-container]');
+    const template = document.getElementById('planner-item-template');
+    const addBtn = document.querySelector('[data-add-item]');
+    const emptyState = container ? container.querySelector('[data-empty-state]') : null;
+    const horizonSelect = document.querySelector('[data-horizon-selector]');
+    const leftoverPreview = document.querySelector('[data-leftover-preview]');
+
+    const fmt = (value) => {
+      const num = Number.isFinite(value) ? value : 0;
+      return new Intl.NumberFormat(undefined, { style: 'currency', currency: <?= json_encode($mainCurrency) ?> }).format(num);
+    };
+
+    const updateEmptyState = () => {
+      if (!container) return;
+      const hasItems = container.querySelectorAll('[data-item]').length > 0;
+      if (emptyState) {
+        emptyState.style.display = hasItems ? 'none' : '';
+      }
+    };
+
+    const recalcLeftover = () => {
+      const horizon = parseFloat(horizonSelect?.value || '3') || 3;
+      let totalMonthly = 0;
+      container?.querySelectorAll('[data-item]').forEach((panel) => {
+        const target = parseFloat(panel.querySelector('[data-target-input]')?.value || '0');
+        const current = parseFloat(panel.querySelector('[data-current-input]')?.value || '0');
+        const required = Math.max(0, target - current);
+        totalMonthly += horizon > 0 ? required / horizon : 0;
+      });
+      const monthlyIncome = <?= json_encode((float)($incomeData['total'] ?? 0)) ?>;
+      const leftover = Math.max(0, monthlyIncome - totalMonthly);
+      if (leftoverPreview) {
+        leftoverPreview.textContent = <?= json_encode(__('Leftover estimate: :amount/month')) ?>.replace(':amount', fmt(leftover));
+      }
+      const averages = Array.from(document.querySelectorAll('[data-category-average]'));
+      const suggestedInputs = Array.from(document.querySelectorAll('[data-category-suggested]'));
+      const totalAverage = averages.reduce((sum, input) => sum + (parseFloat(input.value || '0') || 0), 0);
+      const scale = totalAverage > 0 ? leftover / totalAverage : 0;
+      suggestedInputs.forEach((input, idx) => {
+        const avgInput = averages[idx];
+        const avg = parseFloat(avgInput?.value || '0') || 0;
+        let suggested = 0;
+        if (totalAverage > 0) {
+          suggested = Math.max(0, avg * scale);
+        } else {
+          suggested = averages.length ? leftover / averages.length : 0;
+        }
+        input.value = suggested.toFixed(2);
+      });
+      document.querySelectorAll('[data-category-suggested-display]').forEach((cell, idx) => {
+        const val = parseFloat(suggestedInputs[idx]?.value || '0') || 0;
+        cell.textContent = fmt(val);
+      });
+    };
+
+    const recalcPanel = (panel) => {
+      const horizon = parseFloat(horizonSelect?.value || '3') || 3;
+      const target = parseFloat(panel.querySelector('[data-target-input]')?.value || '0');
+      const current = parseFloat(panel.querySelector('[data-current-input]')?.value || '0');
+      const required = Math.max(0, target - current);
+      const monthly = horizon > 0 ? required / horizon : 0;
+      const output = panel.querySelector('[data-monthly-output]');
+      if (output) {
+        output.textContent = fmt(monthly);
+      }
+    };
+
+    const attachListeners = (panel) => {
+      const inputs = panel.querySelectorAll('[data-target-input], [data-current-input]');
+      inputs.forEach((input) => {
+        input.addEventListener('input', () => {
+          recalcPanel(panel);
+          recalcLeftover();
+        });
+      });
+      const removeBtn = panel.querySelector('[data-remove-item]');
+      removeBtn?.addEventListener('click', () => {
+        panel.remove();
+        updateEmptyState();
+        recalcLeftover();
+      });
+    };
+
+    const addItem = (prefill = {}) => {
+      if (!template || !container) return;
+      const node = template.content.firstElementChild.cloneNode(true);
+      const label = node.querySelector('input[name="item_label[]"]');
+      const type = node.querySelector('select[name="item_type[]"]');
+      const target = node.querySelector('input[name="item_target[]"]');
+      const current = node.querySelector('input[name="item_current[]"]');
+      const priority = node.querySelector('input[name="item_priority[]"]');
+      const reference = node.querySelector('input[name="item_reference[]"]');
+      const notes = node.querySelector('textarea[name="item_notes[]"]');
+      if (prefill.label) label.value = prefill.label;
+      if (prefill.kind) type.value = prefill.kind;
+      if (prefill.target !== undefined) target.value = prefill.target;
+      if (prefill.current !== undefined) current.value = prefill.current;
+      if (prefill.priority) priority.value = prefill.priority;
+      if (prefill.reference) reference.value = prefill.reference;
+      if (prefill.notes) notes.value = prefill.notes;
+      container.appendChild(node);
+      const panel = container.lastElementChild;
+      attachListeners(panel);
+      recalcPanel(panel);
+      recalcLeftover();
+      updateEmptyState();
+    };
+
+    addBtn?.addEventListener('click', () => addItem());
+    horizonSelect?.addEventListener('change', () => {
+      container?.querySelectorAll('[data-item]').forEach((panel) => recalcPanel(panel));
+      recalcLeftover();
+    });
+
+    document.querySelectorAll('[data-quick-add]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const prefill = {
+          label: btn.dataset.label || '',
+          kind: btn.dataset.kind || 'custom',
+          target: parseFloat(btn.dataset.target || '0') || 0,
+          current: parseFloat(btn.dataset.current || '0') || 0,
+          priority: (container?.querySelectorAll('[data-item]').length || 0) + 1,
+          reference: btn.dataset.reference || '',
+          notes: btn.dataset.notes || ''
+        };
+        addItem(prefill);
+      });
+    });
+
+    updateEmptyState();
+    recalcLeftover();
+  });
+</script>

--- a/views/layout/header.php
+++ b/views/layout/header.php
@@ -1093,6 +1093,7 @@
       ['href'=>'/',              'label'=>'Dashboard',        'match'=>'#^/$#',                    'icon' => 'layout-dashboard'],
       ['href'=>'/current-month', 'label'=>'Months',    'match'=>'#^/current-month$#',       'icon' => 'calendar'],
       ['href'=>'/goals',         'label'=>'Goals',            'match'=>'#^/goals(?:/.*)?$#',       'icon' => 'goal'],
+      ['href'=>'/advanced-planner','label'=>'Advanced planner','match'=>'#^/advanced-planner(?:/.*)?$#','icon' => 'route'],
       ['href'=>'/loans',         'label'=>'Loans',            'match'=>'#^/loans(?:/.*)?$#',       'icon' => 'landmark'],
       ['href'=>'/emergency',     'label'=>'Emergency Fund',   'match'=>'#^/emergency(?:/.*)?$#',   'icon' => 'life-buoy'],
       ['href'=>'/scheduled',     'label'=>'Scheduled',        'match'=>'#^/scheduled(?:/.*)?$#',   'icon' => 'calendar-clock'],


### PR DESCRIPTION
## Summary
- add database tables for advanced plans, milestones, and suggested category limits
- implement advanced planner controller with creation, activation, and deletion flows plus data aggregation helpers
- build advanced planner UI with quick-add milestones, spending limit suggestions, and plan management; expose it in navigation

## Testing
- php -l src/controllers/advanced_planner.php
- php -l views/advanced_planner/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d83f4ced74832999680a701f832806