### PR TITLE
Finalize stocks trade engine and tests

### DIFF
--- a/docs/stocks.md
+++ b/docs/stocks.md
@@ -1,0 +1,60 @@
+# Stocks module
+
+The Stocks feature relies on external market data providers. Configure credentials in your environment file:
+
+```
+STOCKS_PROVIDER=finnhub
+FINNHUB_API_KEY=your-key-here
+```
+
+If no provider is configured the app falls back to cached/local prices.
+
+## Database migrations
+
+Run the migrations to create equity tables:
+
+```
+php scripts/migrate.php
+```
+
+This will create the following tables:
+
+- `stocks`, `stock_prices_last`, `price_daily`
+- `stock_positions`, `stock_lots`, `stock_realized_pl`
+- `watchlist`, `user_settings_stocks`
+
+Existing `stock_trades` entries are migrated automatically. Each distinct symbol becomes a `stocks` entry and historical trades are re-linked.
+
+## Backfilling prices
+
+Use the CLI script to import historical daily candles:
+
+```
+php scripts/stocks_backfill.php AAPL MSFT --range=1Y
+```
+
+This populates the `price_daily` table for the requested symbols. The service automatically fetches missing history when rendering charts, but backfilling improves responsiveness.
+
+## Cost basis settings
+
+Users can configure preferred cost-basis methods in `user_settings_stocks`:
+
+- `cost_basis_unrealized`: defaults to `AVERAGE`
+- `realized_method`: defaults to `FIFO`
+- `target_allocations`: optional JSON map of symbol to target weight percentage
+
+These values influence portfolio insights and suggestions.
+
+## Live pricing
+
+The `PriceDataService` caches quotes in memory and in `stock_prices_last`. Client pages poll `/api/stocks/live` every few seconds. To reduce provider usage the backend de-bounces repeated requests and uses cached data when API limits are hit.
+
+## Testing
+
+Unit tests live under `tests/` and can be executed with:
+
+```
+php tests/stocks_tests.php
+```
+
+The suite covers FIFO cost basis, average cost recalculation, FX conversion and signal generation.

--- a/index.php
+++ b/index.php
@@ -33,11 +33,15 @@ require $root . '/src/fx.php';
 
 spl_autoload_register(function (string $class): void {
     $prefix = 'MyMoneyMap\';
+    $root = __DIR__;
+
     if (!str_starts_with($class, $prefix)) {
         return;
     }
+
     $relative = substr($class, strlen($prefix));
     $file = $root . '/src/' . str_replace('\', '/', $relative) . '.php';
+
     if (is_file($file)) {
         require $file;
     }

--- a/migrations/021_stocks_feature.sql
+++ b/migrations/021_stocks_feature.sql
@@ -1,0 +1,142 @@
+-- Stocks feature schema upgrade
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS stocks (
+  id SERIAL PRIMARY KEY,
+  symbol TEXT NOT NULL,
+  exchange TEXT NOT NULL DEFAULT 'GENERIC',
+  name TEXT,
+  currency TEXT NOT NULL DEFAULT 'USD',
+  sector TEXT,
+  industry TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(symbol, exchange)
+);
+
+CREATE TABLE IF NOT EXISTS stock_prices_last (
+  stock_id INT PRIMARY KEY REFERENCES stocks(id) ON DELETE CASCADE,
+  last NUMERIC(18,6) NOT NULL DEFAULT 0,
+  prev_close NUMERIC(18,6) NOT NULL DEFAULT 0,
+  day_high NUMERIC(18,6) NOT NULL DEFAULT 0,
+  day_low NUMERIC(18,6) NOT NULL DEFAULT 0,
+  volume NUMERIC(18,2) NOT NULL DEFAULT 0,
+  provider_ts TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS price_daily (
+  id SERIAL PRIMARY KEY,
+  stock_id INT NOT NULL REFERENCES stocks(id) ON DELETE CASCADE,
+  date DATE NOT NULL,
+  open NUMERIC(18,6) NOT NULL DEFAULT 0,
+  high NUMERIC(18,6) NOT NULL DEFAULT 0,
+  low NUMERIC(18,6) NOT NULL DEFAULT 0,
+  close NUMERIC(18,6) NOT NULL DEFAULT 0,
+  volume NUMERIC(18,2) NOT NULL DEFAULT 0,
+  provider TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (stock_id, date)
+);
+
+CREATE TABLE IF NOT EXISTS stock_positions (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  stock_id INT NOT NULL REFERENCES stocks(id) ON DELETE CASCADE,
+  qty NUMERIC(18,6) NOT NULL DEFAULT 0,
+  avg_cost_ccy NUMERIC(18,6) NOT NULL DEFAULT 0,
+  avg_cost_currency TEXT NOT NULL DEFAULT 'USD',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id, stock_id)
+);
+
+CREATE TABLE IF NOT EXISTS stock_lots (
+  id SERIAL PRIMARY KEY,
+  position_id INT NOT NULL REFERENCES stock_positions(id) ON DELETE CASCADE,
+  qty_open NUMERIC(18,6) NOT NULL,
+  qty_closed NUMERIC(18,6) NOT NULL DEFAULT 0,
+  open_price NUMERIC(18,6) NOT NULL,
+  fee NUMERIC(18,4) NOT NULL DEFAULT 0,
+  currency TEXT NOT NULL DEFAULT 'USD',
+  opened_at TIMESTAMPTZ NOT NULL,
+  closed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS stock_realized_pl (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  stock_id INT NOT NULL REFERENCES stocks(id) ON DELETE CASCADE,
+  sell_trade_id INT,
+  realized_pl_base NUMERIC(18,6) NOT NULL DEFAULT 0,
+  realized_pl_ccy NUMERIC(18,6) NOT NULL DEFAULT 0,
+  method TEXT NOT NULL DEFAULT 'FIFO',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS watchlist (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  stock_id INT NOT NULL REFERENCES stocks(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id, stock_id)
+);
+
+CREATE TABLE IF NOT EXISTS user_settings_stocks (
+  user_id INT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  cost_basis_unrealized TEXT NOT NULL DEFAULT 'AVERAGE',
+  realized_method TEXT NOT NULL DEFAULT 'FIFO',
+  target_allocations JSONB
+);
+
+ALTER TABLE stock_trades RENAME COLUMN quantity TO qty_old;
+ALTER TABLE stock_trades ADD COLUMN qty NUMERIC(18,6);
+UPDATE stock_trades SET qty = qty_old;
+ALTER TABLE stock_trades DROP COLUMN qty_old;
+
+ALTER TABLE stock_trades ADD COLUMN stock_id INT;
+ALTER TABLE stock_trades ADD COLUMN fee NUMERIC(18,4) NOT NULL DEFAULT 0;
+ALTER TABLE stock_trades ADD COLUMN executed_at TIMESTAMPTZ;
+ALTER TABLE stock_trades ADD COLUMN note TEXT;
+ALTER TABLE stock_trades ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE stock_trades ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+UPDATE stock_trades SET executed_at = COALESCE(trade_on::timestamptz, NOW());
+ALTER TABLE stock_trades DROP COLUMN trade_on;
+
+-- Populate stocks table from legacy trades
+INSERT INTO stocks(symbol, exchange, name, currency)
+SELECT DISTINCT symbol, 'LEGACY', symbol, COALESCE(currency, 'USD')
+FROM stock_trades
+WHERE symbol IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+UPDATE stock_trades st SET stock_id = s.id
+FROM stocks s
+WHERE s.symbol = st.symbol
+  AND st.stock_id IS NULL;
+
+ALTER TABLE stock_trades
+  ALTER COLUMN stock_id SET NOT NULL,
+  ALTER COLUMN executed_at SET NOT NULL,
+  ALTER COLUMN side TYPE TEXT,
+  ALTER COLUMN side SET NOT NULL,
+  ALTER COLUMN qty SET NOT NULL,
+  ALTER COLUMN currency SET NOT NULL;
+
+UPDATE stock_trades SET side = UPPER(side);
+
+ALTER TABLE stock_trades ADD CONSTRAINT stock_trades_side_check CHECK (side IN ('BUY','SELL'));
+ALTER TABLE stock_trades ADD CONSTRAINT stock_trades_stock_fk FOREIGN KEY (stock_id) REFERENCES stocks(id) ON DELETE CASCADE;
+
+DROP VIEW IF EXISTS v_stock_positions;
+
+CREATE INDEX IF NOT EXISTS idx_stock_positions_user ON stock_positions(user_id);
+CREATE INDEX IF NOT EXISTS idx_stock_lots_position ON stock_lots(position_id);
+CREATE INDEX IF NOT EXISTS idx_price_daily_stock_date ON price_daily(stock_id, date);
+CREATE INDEX IF NOT EXISTS idx_stock_realized_user_stock ON stock_realized_pl(user_id, stock_id);
+
+COMMIT;

--- a/migrations/021_stocks_feature.sql
+++ b/migrations/021_stocks_feature.sql
@@ -92,6 +92,9 @@ CREATE TABLE IF NOT EXISTS user_settings_stocks (
   target_allocations JSONB
 );
 
+-- Drop dependent legacy view before mutating stock_trades columns.
+DROP VIEW IF EXISTS v_stock_positions;
+
 ALTER TABLE stock_trades RENAME COLUMN quantity TO qty_old;
 ALTER TABLE stock_trades ADD COLUMN qty NUMERIC(18,6);
 UPDATE stock_trades SET qty = qty_old;
@@ -131,8 +134,6 @@ UPDATE stock_trades SET side = UPPER(side);
 
 ALTER TABLE stock_trades ADD CONSTRAINT stock_trades_side_check CHECK (side IN ('BUY','SELL'));
 ALTER TABLE stock_trades ADD CONSTRAINT stock_trades_stock_fk FOREIGN KEY (stock_id) REFERENCES stocks(id) ON DELETE CASCADE;
-
-DROP VIEW IF EXISTS v_stock_positions;
 
 CREATE INDEX IF NOT EXISTS idx_stock_positions_user ON stock_positions(user_id);
 CREATE INDEX IF NOT EXISTS idx_stock_lots_position ON stock_lots(position_id);

--- a/scripts/stocks_backfill.php
+++ b/scripts/stocks_backfill.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+require $root . '/config/load_env.php';
+$config = require $root . '/config/config.php';
+require $root . '/config/db.php';
+require $root . '/src/helpers.php';
+require $root . '/src/fx.php';
+
+spl_autoload_register(function (string $class) use ($root): void {
+    $prefix = 'MyMoneyMap\\';
+    if (!str_starts_with($class, $prefix)) {
+        return;
+    }
+    $relative = substr($class, strlen($prefix));
+    $file = $root . '/src/' . str_replace('\\', '/', $relative) . '.php';
+    if (is_file($file)) {
+        require $file;
+    }
+});
+
+use MyMoneyMap\Stocks\Adapters\FinnhubAdapter;
+use MyMoneyMap\Stocks\Adapters\NullAdapter;
+use MyMoneyMap\Stocks\Repositories\PriceRepository;
+use MyMoneyMap\Stocks\Repositories\SettingsRepository;
+use MyMoneyMap\Stocks\Repositories\StockRepository;
+use MyMoneyMap\Stocks\Repositories\TradeRepository;
+use MyMoneyMap\Stocks\Services\PriceDataService;
+use MyMoneyMap\Stocks\Services\SignalsService;
+use MyMoneyMap\Stocks\Services\PortfolioService;
+use MyMoneyMap\Stocks\Services\TradeService;
+use MyMoneyMap\Stocks\Services\ChartsService;
+
+$options = getopt('', ['range::']);
+$range = strtoupper($options['range'] ?? '1Y');
+$symbols = array_values(array_filter(array_slice($argv, 1), static fn ($arg) => !str_starts_with($arg, '--')));
+
+if ($symbols === []) {
+    fwrite(STDERR, "Usage: php scripts/stocks_backfill.php SYMBOL [SYMBOL...] [--range=1Y]\n");
+    exit(1);
+}
+
+$pdo = $pdo ?? null;
+if (!$pdo instanceof PDO) {
+    fwrite(STDERR, "Database connection missing.\n");
+    exit(1);
+}
+
+$provider = strtolower(getenv('STOCKS_PROVIDER') ?: 'null');
+$adapter = match ($provider) {
+    'finnhub' => new FinnhubAdapter(getenv('FINNHUB_API_KEY') ?: ''),
+    default => new NullAdapter(),
+};
+
+$priceRepo = new PriceRepository($pdo);
+$stockRepo = new StockRepository($pdo);
+$tradeRepo = new TradeRepository($pdo);
+$settingsRepo = new SettingsRepository($pdo);
+$priceService = new PriceDataService($priceRepo, $adapter, 5);
+$signals = new SignalsService($pdo, $priceService, $settingsRepo);
+$portfolio = new PortfolioService($pdo, $tradeRepo, $stockRepo, $settingsRepo, $priceService, $signals);
+$tradeService = new TradeService($pdo, $stockRepo, $tradeRepo, $settingsRepo);
+$charts = new ChartsService($pdo, $tradeRepo, $priceService);
+
+$to = new DateTimeImmutable();
+$from = match ($range) {
+    '1W' => $to->sub(new DateInterval('P7D')),
+    '1M' => $to->sub(new DateInterval('P1M')),
+    '3M' => $to->sub(new DateInterval('P3M')),
+    '6M' => $to->sub(new DateInterval('P6M')),
+    '5Y' => $to->sub(new DateInterval('P5Y')),
+    default => $to->sub(new DateInterval('P1Y')),
+};
+
+foreach ($symbols as $symbolRaw) {
+    $symbol = strtoupper(trim($symbolRaw));
+    if ($symbol === '') {
+        continue;
+    }
+    $stock = $stockRepo->findOneBySymbol($symbol);
+    if (!$stock) {
+        $stockId = $stockRepo->upsert([
+            'symbol' => $symbol,
+            'exchange' => 'MANUAL',
+            'name' => $symbol,
+            'currency' => 'USD',
+        ]);
+        $stock = $stockRepo->findByIds([$stockId])[0] ?? null;
+    }
+    if (!$stock) {
+        fwrite(STDERR, "Could not ensure stock record for {$symbol}\n");
+        continue;
+    }
+
+    $history = $priceService->getDailyHistory((int) $stock['id'], $symbol, $from, $to);
+    $count = iterator_count($history->getIterator());
+    fwrite(STDOUT, "Fetched {$count} candles for {$symbol} ({$from->format('Y-m-d')} -> {$to->format('Y-m-d')})\n");
+}

--- a/src/Stocks/Adapters/FinnhubAdapter.php
+++ b/src/Stocks/Adapters/FinnhubAdapter.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\Adapters;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use MyMoneyMap\Stocks\DTO\LiveQuote;
+use MyMoneyMap\Stocks\DTO\QuoteHistory;
+use MyMoneyMap\Stocks\DTO\QuoteHistoryPoint;
+
+final class FinnhubAdapter implements PriceProviderAdapter
+{
+    public function __construct(private readonly string $apiKey)
+    {
+    }
+
+    /**
+     * @param array<int, string> $symbols
+     * @return array<string, LiveQuote>
+     */
+    public function fetchLiveQuotes(array $symbols): array
+    {
+        if ($this->apiKey === '') {
+            return [];
+        }
+
+        $result = [];
+        foreach ($symbols as $symbol) {
+            $json = $this->httpGet('https://finnhub.io/api/v1/quote?symbol=' . urlencode($symbol));
+            if (!$json) {
+                continue;
+            }
+            $data = json_decode($json, true);
+            if (!is_array($data) || !isset($data['c'])) {
+                continue;
+            }
+            $asOf = isset($data['t']) ? (new DateTimeImmutable())->setTimestamp((int) $data['t']) : new DateTimeImmutable();
+            $result[$symbol] = new LiveQuote(
+                $symbol,
+                (float) ($data['c'] ?? 0),
+                (float) ($data['pc'] ?? 0),
+                (float) ($data['h'] ?? 0),
+                (float) ($data['l'] ?? 0),
+                (float) ($data['v'] ?? 0),
+                $asOf,
+                false
+            );
+        }
+
+        return $result;
+    }
+
+    public function fetchDailyHistory(string $symbol, DateTimeInterface $from, DateTimeInterface $to): QuoteHistory
+    {
+        if ($this->apiKey === '') {
+            return new QuoteHistory([], DateTimeImmutable::createFromInterface($from), DateTimeImmutable::createFromInterface($to));
+        }
+
+        $fromTs = $from->getTimestamp();
+        $toTs = $to->getTimestamp();
+        $json = $this->httpGet(sprintf('https://finnhub.io/api/v1/stock/candle?symbol=%s&resolution=D&from=%d&to=%d', urlencode($symbol), $fromTs, $toTs));
+        if (!$json) {
+            return new QuoteHistory([], DateTimeImmutable::createFromInterface($from), DateTimeImmutable::createFromInterface($to));
+        }
+        $data = json_decode($json, true);
+        if (!is_array($data) || ($data['s'] ?? null) !== 'ok') {
+            return new QuoteHistory([], DateTimeImmutable::createFromInterface($from), DateTimeImmutable::createFromInterface($to));
+        }
+
+        $points = [];
+        $count = count($data['t'] ?? []);
+        for ($i = 0; $i < $count; $i++) {
+            $date = (new DateTimeImmutable())->setTimestamp((int) $data['t'][$i])->setTime(0, 0);
+            $points[] = new QuoteHistoryPoint(
+                $date,
+                (float) $data['o'][$i],
+                (float) $data['h'][$i],
+                (float) $data['l'][$i],
+                (float) $data['c'][$i],
+                (float) $data['v'][$i],
+                false
+            );
+        }
+
+        if ($points === []) {
+            return new QuoteHistory([], DateTimeImmutable::createFromInterface($from), DateTimeImmutable::createFromInterface($to));
+        }
+
+        $first = $points[0]->date;
+        $last = $points[count($points) - 1]->date;
+        return new QuoteHistory($points, $first, $last);
+    }
+
+    private function httpGet(string $url): ?string
+    {
+        $queryGlue = str_contains($url, '?') ? '&' : '?';
+        $finalUrl = $url . $queryGlue . 'token=' . urlencode($this->apiKey);
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'timeout' => 8,
+                'header' => "Accept: application/json\r\n",
+            ],
+        ]);
+
+        $response = @file_get_contents($finalUrl, false, $context);
+        if ($response === false) {
+            return null;
+        }
+        return $response;
+    }
+}

--- a/src/Stocks/Adapters/NullAdapter.php
+++ b/src/Stocks/Adapters/NullAdapter.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\Adapters;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use MyMoneyMap\Stocks\DTO\LiveQuote;
+use MyMoneyMap\Stocks\DTO\QuoteHistory;
+
+final class NullAdapter implements PriceProviderAdapter
+{
+    /**
+     * @param array<int, string> $symbols
+     * @return array<string, LiveQuote>
+     */
+    public function fetchLiveQuotes(array $symbols): array
+    {
+        $now = new DateTimeImmutable();
+        $quotes = [];
+        foreach ($symbols as $symbol) {
+            $quotes[$symbol] = new LiveQuote($symbol, 0.0, 0.0, 0.0, 0.0, 0.0, $now, true);
+        }
+        return $quotes;
+    }
+
+    public function fetchDailyHistory(string $symbol, DateTimeInterface $from, DateTimeInterface $to): QuoteHistory
+    {
+        return new QuoteHistory([], DateTimeImmutable::createFromInterface($from), DateTimeImmutable::createFromInterface($to));
+    }
+}

--- a/src/Stocks/Adapters/PriceProviderAdapter.php
+++ b/src/Stocks/Adapters/PriceProviderAdapter.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\Adapters;
+
+use DateTimeInterface;
+use MyMoneyMap\Stocks\DTO\LiveQuote;
+use MyMoneyMap\Stocks\DTO\QuoteHistory;
+
+interface PriceProviderAdapter
+{
+    /**
+     * @param array<int, string> $symbols
+     * @return array<string, LiveQuote>
+     */
+    public function fetchLiveQuotes(array $symbols): array;
+
+    /**
+     * @return QuoteHistory
+     */
+    public function fetchDailyHistory(string $symbol, DateTimeInterface $from, DateTimeInterface $to): QuoteHistory;
+}

--- a/src/Stocks/Controllers/StocksController.php
+++ b/src/Stocks/Controllers/StocksController.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\Controllers;
+
+use DateInterval;
+use DateTimeImmutable;
+use MyMoneyMap\Stocks\DTO\TradeInput;
+use MyMoneyMap\Stocks\Repositories\SettingsRepository;
+use MyMoneyMap\Stocks\Repositories\StockRepository;
+use MyMoneyMap\Stocks\Repositories\TradeRepository;
+use MyMoneyMap\Stocks\Services\ChartsService;
+use MyMoneyMap\Stocks\Services\PortfolioService;
+use MyMoneyMap\Stocks\Services\PriceDataService;
+use MyMoneyMap\Stocks\Services\SignalsService;
+use MyMoneyMap\Stocks\Services\TradeService;
+use PDO;
+use RuntimeException;
+
+use function json_response;
+use function uid;
+use function view;
+use function verify_csrf;
+
+final class StocksController
+{
+    public function __construct(
+        private readonly PDO $pdo,
+        private readonly PortfolioService $portfolio,
+        private readonly TradeService $tradeService,
+        private readonly ChartsService $charts,
+        private readonly PriceDataService $prices,
+        private readonly StockRepository $stocks,
+        private readonly SettingsRepository $settings,
+        private readonly SignalsService $signals,
+        private readonly TradeRepository $tradeRepo,
+    ) {
+    }
+
+    public function index(): void
+    {
+        $userId = uid();
+        $realizedRange = isset($_GET['realized']) ? (string) $_GET['realized'] : '1M';
+        $filters = [
+            'search' => $_GET['search'] ?? null,
+            'currency' => $_GET['currency'] ?? null,
+            'sector' => $_GET['sector'] ?? null,
+            'watchlist' => isset($_GET['watchlist']) ? (bool) $_GET['watchlist'] : false,
+        ];
+        $snapshot = $this->portfolio->buildSnapshot($userId, $realizedRange, $filters);
+        $trades = $this->tradeRepo->tradesForUser($userId, 100);
+        $chartRange = isset($_GET['chart_range']) ? (string) $_GET['chart_range'] : '3M';
+        $portfolioChart = $this->charts->portfolioValueSeries($userId, $chartRange);
+        $settings = $this->settings->userSettings($userId);
+
+        view('stocks/index', [
+            'snapshot' => $snapshot,
+            'trades' => $trades,
+            'realizedRange' => $realizedRange,
+            'chartRange' => $chartRange,
+            'portfolioChart' => $portfolioChart,
+            'filters' => $filters,
+            'settings' => $settings,
+        ]);
+    }
+
+    public function show(string $symbol): void
+    {
+        $userId = uid();
+        $stock = $this->stocks->findOneBySymbol($symbol);
+        if (!$stock) {
+            throw new RuntimeException('Stock not found');
+        }
+
+        $snapshot = $this->portfolio->buildSnapshot($userId, '1M', ['search' => $symbol]);
+        $holding = null;
+        foreach ($snapshot->holdings as $item) {
+            if ($item->symbol === $symbol) {
+                $holding = $item;
+                break;
+            }
+        }
+        $quote = $this->prices->getLiveQuotes([[
+            'stock_id' => (int) $stock['id'],
+            'symbol' => (string) $stock['symbol'],
+            'exchange' => (string) $stock['exchange'],
+        ]]);
+        $quote = $quote[(int) $stock['id']] ?? null;
+
+        $priceSeries = $this->charts->stockPriceSeries((int) $stock['id'], (string) $stock['symbol'], '6M');
+        $positionSeries = $this->charts->positionValueSeries($userId, (int) $stock['id'], (string) $stock['symbol'], (string) $stock['currency'], '6M');
+        $realizedYtd = $this->tradeRepo->sumRealizedForStock($userId, (int) $stock['id'], new DateTimeImmutable(date('Y-01-01')), new DateTimeImmutable());
+        $insights = $holding ? $this->signals->positionInsights($userId, $holding) : [];
+        $settings = $this->settings->userSettings($userId);
+        $watchlist = $this->stocks->watchlistStockIds($userId);
+        $isWatched = in_array((int) $stock['id'], $watchlist, true);
+
+        view('stocks/show', [
+            'stock' => $stock,
+            'holding' => $holding,
+            'quote' => $quote,
+            'priceSeries' => $priceSeries,
+            'positionSeries' => $positionSeries,
+            'realizedYtd' => $realizedYtd,
+            'insights' => $insights,
+            'settings' => $settings,
+        ]);
+    }
+
+    public function recordTrade(string $side): void
+    {
+        verify_csrf();
+        $side = strtoupper($side);
+        if (!in_array($side, ['BUY', 'SELL'], true)) {
+            throw new RuntimeException('Invalid trade side.');
+        }
+        $executedInput = $_POST['executed_at'] ?? ($_POST['trade_on'] ?? date('Y-m-d'));
+        $executedAt = $this->parseDateTime($executedInput);
+        $input = new TradeInput(
+            uid(),
+            strtoupper(trim((string) ($_POST['symbol'] ?? ''))),
+            strtoupper(trim((string) ($_POST['exchange'] ?? 'NYSE'))),
+            trim((string) ($_POST['name'] ?? ($_POST['symbol'] ?? 'Unknown'))),
+            strtoupper(trim((string) ($_POST['currency'] ?? 'USD'))),
+            $side,
+            (float) ($_POST['quantity'] ?? 0),
+            (float) ($_POST['price'] ?? 0),
+            isset($_POST['fee']) ? (float) $_POST['fee'] : 0.0,
+            $executedAt,
+            isset($_POST['note']) ? (string) $_POST['note'] : null
+        );
+
+        $result = $this->tradeService->recordTrade($input);
+        if ($result->success) {
+            $_SESSION['flash_success'] = 'Trade recorded.';
+        } else {
+            $_SESSION['flash'] = $result->message ?? 'Trade failed.';
+        }
+    }
+
+    public function deleteTrade(): void
+    {
+        verify_csrf();
+        $tradeId = (int) ($_POST['id'] ?? 0);
+        if ($tradeId <= 0) {
+            $_SESSION['flash'] = 'Invalid trade identifier.';
+            return;
+        }
+        $this->tradeService->deleteTrade(uid(), $tradeId);
+        $_SESSION['flash_success'] = 'Trade deleted.';
+    }
+
+    public function toggleWatch(int $stockId): void
+    {
+        verify_csrf();
+        $added = $this->stocks->toggleWatchlist(uid(), $stockId);
+        $_SESSION['flash_success'] = $added ? 'Added to watchlist.' : 'Removed from watchlist.';
+    }
+
+    public function liveQuotes(): void
+    {
+        $symbolsParam = isset($_GET['symbols']) ? explode(',', (string) $_GET['symbols']) : [];
+        $requests = [];
+        foreach ($symbolsParam as $symbol) {
+            $symbol = strtoupper(trim($symbol));
+            if ($symbol === '') {
+                continue;
+            }
+            $stock = $this->stocks->findOneBySymbol($symbol);
+            if ($stock) {
+                $requests[] = [
+                    'stock_id' => (int) $stock['id'],
+                    'symbol' => (string) $stock['symbol'],
+                    'exchange' => (string) $stock['exchange'],
+                ];
+            }
+        }
+        $quotes = $this->prices->getLiveQuotes($requests);
+        $payload = [];
+        foreach ($quotes as $stockId => $quote) {
+            $payload[] = [
+                'stock_id' => $stockId,
+                'symbol' => $quote->symbol,
+                'last' => $quote->last,
+                'prev_close' => $quote->previousClose,
+                'day_high' => $quote->dayHigh,
+                'day_low' => $quote->dayLow,
+                'volume' => $quote->volume,
+                'as_of' => $quote->asOf->format(DateTimeImmutable::ATOM),
+                'stale' => $quote->stale,
+            ];
+        }
+        json_response(['quotes' => $payload]);
+    }
+
+    public function history(string $symbol): void
+    {
+        $range = isset($_GET['range']) ? (string) $_GET['range'] : '6M';
+        [$from, $to] = $this->rangeToDates($range);
+        $stock = $this->stocks->findOneBySymbol($symbol);
+        if (!$stock) {
+            json_response(['candles' => []]);
+            return;
+        }
+        $history = $this->prices->getDailyHistory((int) $stock['id'], $symbol, $from, $to);
+        $series = [];
+        foreach ($history as $point) {
+            $series[] = [
+                'date' => $point->date->format('Y-m-d'),
+                'open' => $point->open,
+                'high' => $point->high,
+                'low' => $point->low,
+                'close' => $point->close,
+                'volume' => $point->volume,
+            ];
+        }
+        json_response(['candles' => $series]);
+    }
+
+    private function parseDateTime(string $input): DateTimeImmutable
+    {
+        $input = trim($input);
+        if ($input === '') {
+            return new DateTimeImmutable();
+        }
+        if (str_contains($input, 'T')) {
+            $dt = DateTimeImmutable::createFromFormat('Y-m-d\TH:i', $input);
+            if ($dt instanceof DateTimeImmutable) {
+                return $dt;
+            }
+        }
+        $dt = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $input);
+        if ($dt instanceof DateTimeImmutable) {
+            return $dt;
+        }
+        $dt = DateTimeImmutable::createFromFormat('Y-m-d', $input);
+        if ($dt instanceof DateTimeImmutable) {
+            return $dt;
+        }
+        return new DateTimeImmutable();
+    }
+
+    /**
+     * @return array{0: DateTimeImmutable, 1: DateTimeImmutable}
+     */
+    private function rangeToDates(string $range): array
+    {
+        $range = strtoupper($range);
+        $to = new DateTimeImmutable();
+        return match ($range) {
+            '1W' => [$to->sub(new DateInterval('P7D')), $to],
+            '1M' => [$to->sub(new DateInterval('P1M')), $to],
+            '3M' => [$to->sub(new DateInterval('P3M')), $to],
+            '6M' => [$to->sub(new DateInterval('P6M')), $to],
+            '1Y' => [$to->sub(new DateInterval('P1Y')), $to],
+            '5Y' => [$to->sub(new DateInterval('P5Y')), $to],
+            default => [$to->sub(new DateInterval('P6M')), $to],
+        };
+    }
+}

--- a/src/Stocks/DTO/AllocationSlice.php
+++ b/src/Stocks/DTO/AllocationSlice.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\DTO;
+
+final class AllocationSlice
+{
+    public function __construct(
+        public readonly string $label,
+        public readonly float $value,
+        public readonly float $weight,
+    ) {
+    }
+}

--- a/src/Stocks/DTO/Holding.php
+++ b/src/Stocks/DTO/Holding.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\DTO;
+
+final class Holding
+{
+    public function __construct(
+        public readonly int $stockId,
+        public readonly string $symbol,
+        public readonly string $exchange,
+        public readonly string $name,
+        public readonly string $currency,
+        public readonly float $quantity,
+        public readonly float $averageCost,
+        public readonly float $averageCostBase,
+        public readonly string $baseCurrency,
+        public readonly float $lastPrice,
+        public readonly float $lastPriceBase,
+        public readonly float $marketValue,
+        public readonly float $marketValueBase,
+        public readonly float $unrealized,
+        public readonly float $unrealizedPercent,
+        public readonly float $dayChange,
+        public readonly float $dayChangeBase,
+        public readonly float $weight,
+        public readonly ?string $sector = null,
+        public readonly ?string $industry = null,
+        public readonly ?string $note = null,
+        public readonly bool $concentrationWarning = false,
+    ) {
+    }
+}

--- a/src/Stocks/DTO/Insight.php
+++ b/src/Stocks/DTO/Insight.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\DTO;
+
+final class Insight
+{
+    public function __construct(
+        public readonly string $title,
+        public readonly string $description,
+        public readonly string $severity,
+    ) {
+    }
+}

--- a/src/Stocks/DTO/LiveQuote.php
+++ b/src/Stocks/DTO/LiveQuote.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\DTO;
+
+use DateTimeImmutable;
+
+final class LiveQuote
+{
+    public function __construct(
+        public readonly string $symbol,
+        public readonly float $last,
+        public readonly float $previousClose,
+        public readonly float $dayHigh,
+        public readonly float $dayLow,
+        public readonly float $volume,
+        public readonly DateTimeImmutable $asOf,
+        public readonly bool $stale = false,
+    ) {
+    }
+
+    public function change(): float
+    {
+        return $this->last - $this->previousClose;
+    }
+
+    public function percentChange(): float
+    {
+        if ($this->previousClose == 0.0) {
+            return 0.0;
+        }
+
+        return ($this->change() / $this->previousClose) * 100.0;
+    }
+}

--- a/src/Stocks/DTO/PortfolioSnapshot.php
+++ b/src/Stocks/DTO/PortfolioSnapshot.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\DTO;
+
+final class PortfolioSnapshot
+{
+    /**
+     * @param list<Holding> $holdings
+     * @param list<WatchlistEntry> $watchlist
+     * @param list<AllocationSlice> $allocationsByTicker
+     * @param list<AllocationSlice> $allocationsBySector
+     * @param list<AllocationSlice> $allocationsByCurrency
+     * @param list<Insight> $insights
+     */
+    public function __construct(
+        public readonly string $baseCurrency,
+        public readonly float $totalMarketValue,
+        public readonly float $totalCost,
+        public readonly float $unrealized,
+        public readonly float $unrealizedPercent,
+        public readonly float $realizedPeriod,
+        public readonly float $cashImpact,
+        public readonly float $dailyPL,
+        public readonly array $holdings,
+        public readonly array $watchlist,
+        public readonly array $allocationsByTicker,
+        public readonly array $allocationsBySector,
+        public readonly array $allocationsByCurrency,
+        public readonly array $insights,
+    ) {
+    }
+}

--- a/src/Stocks/DTO/PositionValuePoint.php
+++ b/src/Stocks/DTO/PositionValuePoint.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\DTO;
+
+use DateTimeImmutable;
+
+final class PositionValuePoint
+{
+    public function __construct(
+        public readonly DateTimeImmutable $date,
+        public readonly float $valueBase,
+    ) {
+    }
+}

--- a/src/Stocks/DTO/QuoteHistory.php
+++ b/src/Stocks/DTO/QuoteHistory.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\DTO;
+
+use DateInterval;
+use DatePeriod;
+use DateTimeImmutable;
+
+final class QuoteHistory implements \IteratorAggregate
+{
+    /**
+     * @param list<QuoteHistoryPoint> $points
+     * @param DateTimeImmutable $from
+     * @param DateTimeImmutable $to
+     */
+    public function __construct(
+        public readonly array $points,
+        public readonly DateTimeImmutable $from,
+        public readonly DateTimeImmutable $to,
+    ) {
+    }
+
+    /**
+     * @return \Traversable<int, QuoteHistoryPoint>
+     */
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->points);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->points === [];
+    }
+
+    public function fillGaps(): QuoteHistory
+    {
+        if ($this->isEmpty()) {
+            return $this;
+        }
+
+        $map = [];
+        foreach ($this->points as $point) {
+            $map[$point->date->format('Y-m-d')] = $point;
+        }
+
+        $filled = [];
+        $period = new DatePeriod($this->from, new DateInterval('P1D'), $this->to->modify('+1 day'));
+        $last = null;
+        foreach ($period as $day) {
+            $key = $day->format('Y-m-d');
+            if (isset($map[$key])) {
+                $filled[] = $map[$key];
+                $last = $map[$key];
+                continue;
+            }
+
+            if ($last) {
+                $filled[] = new QuoteHistoryPoint($day, $last->open, $last->high, $last->low, $last->close, $last->volume, true);
+                continue;
+            }
+        }
+
+        return new QuoteHistory($filled, $this->from, $this->to);
+    }
+}

--- a/src/Stocks/DTO/QuoteHistoryPoint.php
+++ b/src/Stocks/DTO/QuoteHistoryPoint.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\DTO;
+
+use DateTimeImmutable;
+
+final class QuoteHistoryPoint
+{
+    public function __construct(
+        public readonly DateTimeImmutable $date,
+        public readonly float $open,
+        public readonly float $high,
+        public readonly float $low,
+        public readonly float $close,
+        public readonly float $volume,
+        public readonly bool $synthetic = false,
+    ) {
+    }
+}

--- a/src/Stocks/DTO/TradeInput.php
+++ b/src/Stocks/DTO/TradeInput.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\DTO;
+
+use DateTimeImmutable;
+
+final class TradeInput
+{
+    public function __construct(
+        public readonly int $userId,
+        public readonly string $symbol,
+        public readonly string $exchange,
+        public readonly string $name,
+        public readonly string $currency,
+        public readonly string $side,
+        public readonly float $quantity,
+        public readonly float $price,
+        public readonly float $fee,
+        public readonly DateTimeImmutable $executedAt,
+        public readonly ?string $note = null,
+    ) {
+    }
+}

--- a/src/Stocks/DTO/TradeResult.php
+++ b/src/Stocks/DTO/TradeResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\DTO;
+
+final class TradeResult
+{
+    public function __construct(
+        public readonly bool $success,
+        public readonly ?int $tradeId = null,
+        public readonly ?string $message = null,
+    ) {
+    }
+}

--- a/src/Stocks/DTO/WatchlistEntry.php
+++ b/src/Stocks/DTO/WatchlistEntry.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\DTO;
+
+final class WatchlistEntry
+{
+    public function __construct(
+        public readonly int $stockId,
+        public readonly string $symbol,
+        public readonly string $name,
+        public readonly string $exchange,
+        public readonly string $currency,
+        public readonly ?LiveQuote $quote,
+    ) {
+    }
+}

--- a/src/Stocks/Repositories/PriceRepository.php
+++ b/src/Stocks/Repositories/PriceRepository.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\Repositories;
+
+use DateTimeImmutable;
+use PDO;
+
+final class PriceRepository
+{
+    public function __construct(private readonly PDO $pdo)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function lastPrice(int $stockId): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM stock_prices_last WHERE stock_id = ? LIMIT 1');
+        $stmt->execute([$stockId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
+
+    public function upsertLastPrice(int $stockId, array $payload): void
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO stock_prices_last(stock_id, last, prev_close, day_high, day_low, volume, provider_ts) VALUES(?,?,?,?,?,?,?) ON CONFLICT (stock_id) DO UPDATE SET last = EXCLUDED.last, prev_close = EXCLUDED.prev_close, day_high = EXCLUDED.day_high, day_low = EXCLUDED.day_low, volume = EXCLUDED.volume, provider_ts = EXCLUDED.provider_ts, updated_at = CURRENT_TIMESTAMP');
+        $stmt->execute([
+            $stockId,
+            $payload['last'] ?? 0,
+            $payload['prev_close'] ?? 0,
+            $payload['day_high'] ?? 0,
+            $payload['day_low'] ?? 0,
+            $payload['volume'] ?? 0,
+            $payload['provider_ts'] ?? (new DateTimeImmutable())->format('c'),
+        ]);
+    }
+
+    public function insertDailyPrice(int $stockId, DateTimeImmutable $date, array $payload): void
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO price_daily(stock_id, date, open, high, low, close, volume, provider) VALUES(?,?,?,?,?,?,?,?) ON CONFLICT (stock_id, date) DO UPDATE SET open = EXCLUDED.open, high = EXCLUDED.high, low = EXCLUDED.low, close = EXCLUDED.close, volume = EXCLUDED.volume, provider = EXCLUDED.provider, updated_at = CURRENT_TIMESTAMP');
+        $stmt->execute([
+            $stockId,
+            $date->format('Y-m-d'),
+            $payload['open'] ?? 0,
+            $payload['high'] ?? 0,
+            $payload['low'] ?? 0,
+            $payload['close'] ?? 0,
+            $payload['volume'] ?? 0,
+            $payload['provider'] ?? 'local',
+        ]);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function dailySeries(int $stockId, DateTimeImmutable $from, DateTimeImmutable $to): array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM price_daily WHERE stock_id = ? AND date BETWEEN ? AND ? ORDER BY date');
+        $stmt->execute([$stockId, $from->format('Y-m-d'), $to->format('Y-m-d')]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+}

--- a/src/Stocks/Repositories/SettingsRepository.php
+++ b/src/Stocks/Repositories/SettingsRepository.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\Repositories;
+
+use PDO;
+
+final class SettingsRepository
+{
+    public function __construct(private readonly PDO $pdo)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function userSettings(int $userId): array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM user_settings_stocks WHERE user_id = ? LIMIT 1');
+        $stmt->execute([$userId]);
+        $settings = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$settings) {
+            return [
+                'cost_basis_unrealized' => 'AVERAGE',
+                'realized_method' => 'FIFO',
+                'target_allocations' => null,
+            ];
+        }
+
+        return [
+            'cost_basis_unrealized' => $settings['cost_basis_unrealized'] ?? 'AVERAGE',
+            'realized_method' => $settings['realized_method'] ?? 'FIFO',
+            'target_allocations' => $settings['target_allocations'] ?? null,
+        ];
+    }
+}

--- a/src/Stocks/Repositories/StockRepository.php
+++ b/src/Stocks/Repositories/StockRepository.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\Repositories;
+
+use PDO;
+use PDOException;
+use RuntimeException;
+
+final class StockRepository
+{
+    private string $driver;
+
+    public function __construct(private readonly PDO $pdo)
+    {
+        $this->driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME) ?: 'pgsql';
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function findBySymbol(string $symbol, string $exchange): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM stocks WHERE symbol = ? AND exchange = ? LIMIT 1');
+        $stmt->execute([$symbol, $exchange]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    public function create(string $symbol, string $exchange, string $name, string $currency, array $overrides = []): int
+    {
+        if ($this->driver === 'sqlite') {
+            $stmt = $this->pdo->prepare('INSERT INTO stocks(symbol, exchange, name, currency, sector, industry) VALUES(?,?,?,?,?,?)');
+            $stmt->execute([
+                strtoupper($symbol),
+                strtoupper($exchange),
+                $name,
+                strtoupper($currency),
+                $overrides['sector'] ?? null,
+                $overrides['industry'] ?? null,
+            ]);
+            return (int) $this->pdo->lastInsertId();
+        }
+
+        $stmt = $this->pdo->prepare('INSERT INTO stocks(symbol, exchange, name, currency, sector, industry) VALUES(?,?,?,?,?,?) RETURNING id');
+        $stmt->execute([
+            strtoupper($symbol),
+            strtoupper($exchange),
+            $name,
+            strtoupper($currency),
+            $overrides['sector'] ?? null,
+            $overrides['industry'] ?? null,
+        ]);
+
+        $id = $stmt->fetchColumn();
+        if ($id === false) {
+            throw new RuntimeException('Failed to create stock');
+        }
+
+        return (int) $id;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function upsert(array $payload): int
+    {
+        $symbol = strtoupper((string) ($payload['symbol'] ?? ''));
+        $exchange = strtoupper((string) ($payload['exchange'] ?? ''));
+        $name = (string) ($payload['name'] ?? $symbol);
+        $currency = strtoupper((string) ($payload['currency'] ?? 'USD'));
+
+        if ($symbol === '' || $exchange === '') {
+            throw new RuntimeException('Symbol and exchange are required');
+        }
+
+        $existing = $this->findBySymbol($symbol, $exchange);
+        if ($existing) {
+            $stmt = $this->pdo->prepare('UPDATE stocks SET name = ?, currency = ?, sector = COALESCE(?, sector), industry = COALESCE(?, industry), updated_at = CURRENT_TIMESTAMP WHERE id = ?');
+            $stmt->execute([
+                $name,
+                $currency,
+                $payload['sector'] ?? null,
+                $payload['industry'] ?? null,
+                $existing['id'],
+            ]);
+            return (int) $existing['id'];
+        }
+
+        return $this->create($symbol, $exchange, $name, $currency, $payload);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function search(string $term): array
+    {
+        if ($this->driver === 'sqlite') {
+            $stmt = $this->pdo->prepare('SELECT * FROM stocks WHERE UPPER(symbol) LIKE UPPER(?) OR UPPER(name) LIKE UPPER(?) ORDER BY symbol LIMIT 20');
+            $stmt->execute(['%' . $term . '%', '%' . $term . '%']);
+            return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+        }
+
+        $stmt = $this->pdo->prepare('SELECT * FROM stocks WHERE symbol ILIKE ? OR name ILIKE ? ORDER BY symbol LIMIT 20');
+        $stmt->execute(['%' . $term . '%', '%' . $term . '%']);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function findOneBySymbol(string $symbol): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM stocks WHERE symbol = ? LIMIT 1');
+        $stmt->execute([strtoupper($symbol)]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
+
+    public function findByIds(array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $stmt = $this->pdo->prepare("SELECT * FROM stocks WHERE id IN ($placeholders)");
+        $stmt->execute($ids);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function watchlistStockIds(int $userId): array
+    {
+        $stmt = $this->pdo->prepare('SELECT stock_id FROM watchlist WHERE user_id = ? ORDER BY created_at');
+        $stmt->execute([$userId]);
+        return array_map('intval', $stmt->fetchAll(PDO::FETCH_COLUMN) ?: []);
+    }
+
+    public function toggleWatchlist(int $userId, int $stockId): bool
+    {
+        $this->pdo->beginTransaction();
+        try {
+            $stmt = $this->pdo->prepare('SELECT 1 FROM watchlist WHERE user_id = ? AND stock_id = ?');
+            $stmt->execute([$userId, $stockId]);
+            if ($stmt->fetchColumn()) {
+                $del = $this->pdo->prepare('DELETE FROM watchlist WHERE user_id = ? AND stock_id = ?');
+                $del->execute([$userId, $stockId]);
+                $this->pdo->commit();
+                return false;
+            }
+
+            $ins = $this->pdo->prepare('INSERT INTO watchlist(user_id, stock_id) VALUES(?, ?)');
+            $ins->execute([$userId, $stockId]);
+            $this->pdo->commit();
+            return true;
+        } catch (PDOException $e) {
+            $this->pdo->rollBack();
+            throw $e;
+        }
+    }
+}

--- a/src/Stocks/Repositories/TradeRepository.php
+++ b/src/Stocks/Repositories/TradeRepository.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\Repositories;
+
+use DateTimeImmutable;
+use PDO;
+use RuntimeException;
+
+final class TradeRepository
+{
+    private string $driver;
+
+    public function __construct(private readonly PDO $pdo)
+    {
+        $this->driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME) ?: 'pgsql';
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function findPosition(int $userId, int $stockId): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM stock_positions WHERE user_id = ? AND stock_id = ? LIMIT 1');
+        $stmt->execute([$userId, $stockId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
+
+    public function upsertPosition(int $userId, int $stockId, float $qty, float $avgCostCcy, string $currency): int
+    {
+        $existing = $this->findPosition($userId, $stockId);
+        if ($existing) {
+            $stmt = $this->pdo->prepare('UPDATE stock_positions SET qty = ?, avg_cost_ccy = ?, avg_cost_currency = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?');
+            $stmt->execute([$qty, $avgCostCcy, $currency, $existing['id']]);
+            return (int) $existing['id'];
+        }
+
+        if ($this->driver === 'sqlite') {
+            $stmt = $this->pdo->prepare('INSERT INTO stock_positions(user_id, stock_id, qty, avg_cost_ccy, avg_cost_currency) VALUES(?,?,?,?,?)');
+            $stmt->execute([$userId, $stockId, $qty, $avgCostCcy, $currency]);
+            return (int) $this->pdo->lastInsertId();
+        }
+        $stmt = $this->pdo->prepare('INSERT INTO stock_positions(user_id, stock_id, qty, avg_cost_ccy, avg_cost_currency) VALUES(?,?,?,?,?) RETURNING id');
+        $stmt->execute([$userId, $stockId, $qty, $avgCostCcy, $currency]);
+        $id = $stmt->fetchColumn();
+        if ($id === false) {
+            throw new RuntimeException('Failed to create position');
+        }
+        return (int) $id;
+    }
+
+    public function insertTrade(
+        int $userId,
+        int $stockId,
+        string $side,
+        float $qty,
+        float $price,
+        float $fee,
+        string $currency,
+        DateTimeImmutable $executedAt,
+        ?string $note
+    ): int {
+        if ($this->driver === 'sqlite') {
+            $stmt = $this->pdo->prepare('INSERT INTO stock_trades(user_id, stock_id, side, qty, price, fee, currency, executed_at, note) VALUES(?,?,?,?,?,?,?,?,?)');
+            $stmt->execute([$userId, $stockId, $side, $qty, $price, $fee, $currency, $executedAt->format('c'), $note]);
+            return (int) $this->pdo->lastInsertId();
+        }
+        $stmt = $this->pdo->prepare('INSERT INTO stock_trades(user_id, stock_id, side, qty, price, fee, currency, executed_at, note) VALUES(?,?,?,?,?,?,?,?,?) RETURNING id');
+        $stmt->execute([$userId, $stockId, $side, $qty, $price, $fee, $currency, $executedAt->format('c'), $note]);
+        $id = $stmt->fetchColumn();
+        if ($id === false) {
+            throw new RuntimeException('Failed to insert trade');
+        }
+        return (int) $id;
+    }
+
+    public function deleteTrade(int $userId, int $tradeId): void
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM stock_trades WHERE id = ? AND user_id = ?');
+        $stmt->execute([$tradeId, $userId]);
+    }
+
+    public function deleteLots(int $positionId): void
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM stock_lots WHERE position_id = ?');
+        $stmt->execute([$positionId]);
+    }
+
+    public function deleteRealized(int $userId, int $stockId): void
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM stock_realized_pl WHERE user_id = ? AND stock_id = ?');
+        $stmt->execute([$userId, $stockId]);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function tradesForStock(int $userId, int $stockId): array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM stock_trades WHERE user_id = ? AND stock_id = ? ORDER BY executed_at, id');
+        $stmt->execute([$userId, $stockId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    public function createLot(int $positionId, float $qty, float $price, float $fee, string $currency, DateTimeImmutable $openedAt): int
+    {
+        if ($this->driver === 'sqlite') {
+            $stmt = $this->pdo->prepare('INSERT INTO stock_lots(position_id, qty_open, qty_closed, open_price, fee, currency, opened_at) VALUES(?,?,?,?,?,?,?)');
+            $stmt->execute([$positionId, $qty, 0, $price, $fee, $currency, $openedAt->format('c')]);
+            return (int) $this->pdo->lastInsertId();
+        }
+        $stmt = $this->pdo->prepare('INSERT INTO stock_lots(position_id, qty_open, qty_closed, open_price, fee, currency, opened_at) VALUES(?,?,?,?,?,?,?) RETURNING id');
+        $stmt->execute([$positionId, $qty, 0, $price, $fee, $currency, $openedAt->format('c')]);
+        $id = $stmt->fetchColumn();
+        if ($id === false) {
+            throw new RuntimeException('Failed to create lot');
+        }
+        return (int) $id;
+    }
+
+    public function closeLotPartial(int $lotId, float $qtyClosed, bool $fullyClosed, DateTimeImmutable $closedAt): void
+    {
+        $stmt = $this->pdo->prepare('UPDATE stock_lots SET qty_closed = qty_closed + ?, closed_at = CASE WHEN ? THEN ? ELSE closed_at END WHERE id = ?');
+        $stmt->execute([$qtyClosed, $fullyClosed ? 1 : 0, $closedAt->format('c'), $lotId]);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function holdingsRaw(int $userId): array
+    {
+        $stmt = $this->pdo->prepare('SELECT sp.*, s.symbol, s.exchange, s.name, s.currency, s.sector, s.industry FROM stock_positions sp JOIN stocks s ON s.id = sp.stock_id WHERE sp.user_id = ? ORDER BY s.symbol');
+        $stmt->execute([$userId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function openLots(int $positionId): array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM stock_lots WHERE position_id = ? AND qty_open > qty_closed ORDER BY opened_at');
+        $stmt->execute([$positionId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    public function persistRealized(int $userId, int $stockId, int $sellTradeId, float $plBase, float $plCcy, string $method): void
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO stock_realized_pl(user_id, stock_id, sell_trade_id, realized_pl_base, realized_pl_ccy, method) VALUES(?,?,?,?,?,?)');
+        $stmt->execute([$userId, $stockId, $sellTradeId, $plBase, $plCcy, $method]);
+    }
+
+    public function sumRealizedForStock(int $userId, int $stockId, ?DateTimeImmutable $from = null, ?DateTimeImmutable $to = null): float
+    {
+        $sql = 'SELECT COALESCE(SUM(realized_pl_base), 0) FROM stock_realized_pl WHERE user_id = ? AND stock_id = ?';
+        $params = [$userId, $stockId];
+        if ($from) {
+            $sql .= ' AND created_at >= ?';
+            $params[] = $from->format('c');
+        }
+        if ($to) {
+            $sql .= ' AND created_at <= ?';
+            $params[] = $to->format('c');
+        }
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+        return (float) ($stmt->fetchColumn() ?: 0);
+    }
+
+    public function sumRealized(int $userId, ?DateTimeImmutable $from = null, ?DateTimeImmutable $to = null): float
+    {
+        $sql = 'SELECT COALESCE(SUM(realized_pl_base), 0) FROM stock_realized_pl WHERE user_id = ?';
+        $params = [$userId];
+        if ($from) {
+            $sql .= ' AND created_at >= ?';
+            $params[] = $from->format('c');
+        }
+        if ($to) {
+            $sql .= ' AND created_at <= ?';
+            $params[] = $to->format('c');
+        }
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+        return (float) ($stmt->fetchColumn() ?: 0);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function tradesForUser(int $userId, int $limit = 100): array
+    {
+        $stmt = $this->pdo->prepare('SELECT st.*, s.symbol, s.exchange, s.name FROM stock_trades st JOIN stocks s ON s.id = st.stock_id WHERE st.user_id = ? ORDER BY st.executed_at DESC, st.id DESC LIMIT ?');
+        $stmt->bindValue(1, $userId, PDO::PARAM_INT);
+        $stmt->bindValue(2, $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function allTrades(int $userId): array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM stock_trades WHERE user_id = ? ORDER BY executed_at, id');
+        $stmt->execute([$userId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    }
+}

--- a/src/Stocks/Services/ChartsService.php
+++ b/src/Stocks/Services/ChartsService.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\Services;
+
+use DateInterval;
+use DatePeriod;
+use DateTimeImmutable;
+use MyMoneyMap\Stocks\Repositories\TradeRepository;
+use PDO;
+
+use function fx_convert;
+use function fx_user_main;
+
+final class ChartsService
+{
+    public function __construct(
+        private readonly PDO $pdo,
+        private readonly TradeRepository $trades,
+        private readonly PriceDataService $prices,
+    ) {
+    }
+
+    /**
+     * @return array{labels: list<string>, values: list<float>}
+     */
+    public function portfolioValueSeries(int $userId, string $range = '3M'): array
+    {
+        $baseCurrency = fx_user_main($this->pdo, $userId);
+        [$from, $to] = $this->rangeToDates($range);
+        $holdings = $this->trades->holdingsRaw($userId);
+        $dates = $this->buildDateRange($from, $to);
+
+        $priceCache = [];
+        foreach ($holdings as $row) {
+            $stockId = (int) $row['stock_id'];
+            $symbol = (string) $row['symbol'];
+            $history = $this->prices->getDailyHistory($stockId, $symbol, $from, $to);
+            $map = [];
+            foreach ($history as $point) {
+                $map[$point->date->format('Y-m-d')] = $point->close;
+            }
+            $priceCache[$stockId] = $map;
+        }
+
+        $labels = [];
+        $values = [];
+        $totals = [];
+        foreach ($dates as $date) {
+            $dateKey = $date->format('Y-m-d');
+            $labels[] = $date->format('M j');
+            $dailyTotal = 0.0;
+            foreach ($holdings as $row) {
+                $qty = (float) $row['qty'];
+                if ($qty <= 0) {
+                    continue;
+                }
+                $stockId = (int) $row['stock_id'];
+                $currency = strtoupper((string) $row['currency']);
+                $pricesMap = $priceCache[$stockId] ?? [];
+                $price = $pricesMap[$dateKey] ?? $this->nearestPrice($pricesMap, $dateKey);
+                if ($price === null) {
+                    continue;
+                }
+                $dailyTotal += fx_convert($this->pdo, $qty * $price, $currency, $baseCurrency, $dateKey);
+            }
+            $values[] = $dailyTotal;
+            $totals[$dateKey] = $dailyTotal;
+        }
+
+        return ['labels' => $labels, 'values' => $values];
+    }
+
+    /**
+     * @return array{labels: list<string>, values: list<float>}
+     */
+    public function stockPriceSeries(int $stockId, string $symbol, string $range = '6M'): array
+    {
+        [$from, $to] = $this->rangeToDates($range);
+        $history = $this->prices->getDailyHistory($stockId, $symbol, $from, $to);
+        $labels = [];
+        $values = [];
+        foreach ($history as $point) {
+            $labels[] = $point->date->format('M j');
+            $values[] = $point->close;
+        }
+        return ['labels' => $labels, 'values' => $values];
+    }
+
+    /**
+     * @return array{labels: list<string>, values: list<float>}
+     */
+    public function positionValueSeries(int $userId, int $stockId, string $symbol, string $currency, string $range = '6M'): array
+    {
+        $baseCurrency = fx_user_main($this->pdo, $userId);
+        [$from, $to] = $this->rangeToDates($range);
+        $history = $this->prices->getDailyHistory($stockId, $symbol, $from, $to);
+        $priceMap = [];
+        foreach ($history as $point) {
+            $priceMap[$point->date->format('Y-m-d')] = $point->close;
+        }
+
+        $trades = $this->trades->tradesForStock($userId, $stockId);
+        usort($trades, static function (array $a, array $b): int {
+            return strcmp((string) $a['executed_at'], (string) $b['executed_at']);
+        });
+
+        $dates = $this->buildDateRange($from, $to);
+        $labels = [];
+        $values = [];
+        $quantity = 0.0;
+        $index = 0;
+        $count = count($trades);
+
+        foreach ($dates as $date) {
+            while ($index < $count && new DateTimeImmutable((string) $trades[$index]['executed_at']) <= $date) {
+                $side = strtoupper((string) $trades[$index]['side']);
+                $qty = (float) $trades[$index]['qty'];
+                if ($side === 'BUY') {
+                    $quantity += $qty;
+                } elseif ($side === 'SELL') {
+                    $quantity -= $qty;
+                }
+                $index++;
+            }
+
+            $dateKey = $date->format('Y-m-d');
+            $price = $priceMap[$dateKey] ?? $this->nearestPrice($priceMap, $dateKey);
+            if ($price === null) {
+                continue;
+            }
+            $valueBase = fx_convert($this->pdo, $quantity * $price, $currency, $baseCurrency, $dateKey);
+            $labels[] = $date->format('M j');
+            $values[] = $valueBase;
+        }
+
+        return ['labels' => $labels, 'values' => $values];
+    }
+
+    /**
+     * @return list<DateTimeImmutable>
+     */
+    private function buildDateRange(DateTimeImmutable $from, DateTimeImmutable $to): array
+    {
+        $period = new DatePeriod($from, new DateInterval('P1D'), $to->modify('+1 day'));
+        $dates = [];
+        foreach ($period as $day) {
+            $dates[] = DateTimeImmutable::createFromInterface($day);
+        }
+        return $dates;
+    }
+
+    /**
+     * @return array{0: DateTimeImmutable, 1: DateTimeImmutable}
+     */
+    private function rangeToDates(string $range): array
+    {
+        $range = strtoupper($range);
+        $to = new DateTimeImmutable();
+        return match ($range) {
+            '1W' => [$to->sub(new DateInterval('P7D')), $to],
+            '1M' => [$to->sub(new DateInterval('P1M')), $to],
+            '3M' => [$to->sub(new DateInterval('P3M')), $to],
+            '6M' => [$to->sub(new DateInterval('P6M')), $to],
+            '1Y' => [$to->sub(new DateInterval('P1Y')), $to],
+            '5Y' => [$to->sub(new DateInterval('P5Y')), $to],
+            default => [$to->sub(new DateInterval('P3M')), $to],
+        };
+    }
+
+    /**
+     * @param array<string, float> $prices
+     */
+    private function nearestPrice(array $prices, string $dateKey): ?float
+    {
+        if (isset($prices[$dateKey])) {
+            return $prices[$dateKey];
+        }
+        $keys = array_keys($prices);
+        sort($keys);
+        $candidate = null;
+        foreach (array_reverse($keys) as $key) {
+            if ($key <= $dateKey) {
+                $candidate = $prices[$key];
+                break;
+            }
+        }
+        if ($candidate !== null) {
+            return $candidate;
+        }
+        foreach ($keys as $key) {
+            if ($key >= $dateKey) {
+                return $prices[$key];
+            }
+        }
+        return null;
+    }
+}

--- a/src/Stocks/Services/PortfolioService.php
+++ b/src/Stocks/Services/PortfolioService.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\Services;
+
+use DateInterval;
+use DateTimeImmutable;
+use MyMoneyMap\Stocks\DTO\AllocationSlice;
+use MyMoneyMap\Stocks\DTO\Holding;
+use MyMoneyMap\Stocks\DTO\PortfolioSnapshot;
+use MyMoneyMap\Stocks\DTO\WatchlistEntry;
+use MyMoneyMap\Stocks\Repositories\SettingsRepository;
+use MyMoneyMap\Stocks\Repositories\StockRepository;
+use MyMoneyMap\Stocks\Repositories\TradeRepository;
+use PDO;
+
+use function fx_convert;
+use function fx_user_main;
+
+final class PortfolioService
+{
+    public function __construct(
+        private readonly PDO $pdo,
+        private readonly TradeRepository $trades,
+        private readonly StockRepository $stocks,
+        private readonly SettingsRepository $settings,
+        private readonly PriceDataService $prices,
+        private readonly SignalsService $signals,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     */
+    public function buildSnapshot(int $userId, string $realizedRange = '1M', array $filters = []): PortfolioSnapshot
+    {
+        $baseCurrency = fx_user_main($this->pdo, $userId);
+        [$from, $to] = $this->rangeToDates($realizedRange);
+
+        $rawHoldings = $this->trades->holdingsRaw($userId);
+        $watchIds = $this->stocks->watchlistStockIds($userId);
+        $watchStocks = $this->stocks->findByIds($watchIds);
+
+        $quoteRequests = [];
+        foreach ($rawHoldings as $row) {
+            $quoteRequests[$row['stock_id']] = [
+                'stock_id' => (int) $row['stock_id'],
+                'symbol' => $row['symbol'],
+                'exchange' => $row['exchange'],
+            ];
+        }
+        foreach ($watchStocks as $row) {
+            $quoteRequests[$row['id']] = [
+                'stock_id' => (int) $row['id'],
+                'symbol' => $row['symbol'],
+                'exchange' => $row['exchange'],
+            ];
+        }
+
+        $quotes = $quoteRequests !== [] ? $this->prices->getLiveQuotes(array_values($quoteRequests)) : [];
+
+        $filtered = $this->filterHoldings($rawHoldings, $filters, $watchIds);
+
+        $holdingTemp = [];
+        $totalMarketValueBase = 0.0;
+        $totalCostBase = 0.0;
+        $dailyPLBase = 0.0;
+        $unrealizedBaseTotal = 0.0;
+        $allocTicker = [];
+        $allocSector = [];
+        $allocCurrency = [];
+
+        foreach ($filtered as $row) {
+            $qty = (float) $row['qty'];
+            if ($qty <= 1e-6) {
+                continue;
+            }
+            $stockId = (int) $row['stock_id'];
+            $symbol = (string) $row['symbol'];
+            $exchange = (string) $row['exchange'];
+            $name = (string) $row['name'];
+            $currency = strtoupper((string) $row['currency']);
+            $avgCost = (float) $row['avg_cost_ccy'];
+            $sector = $row['sector'] ?: null;
+            $industry = $row['industry'] ?: null;
+            $quote = $quotes[$stockId] ?? null;
+            $lastPrice = $quote?->last ?? $avgCost;
+            $date = $quote ? $quote->asOf->format('Y-m-d') : (new DateTimeImmutable())->format('Y-m-d');
+
+            $avgCostBase = fx_convert($this->pdo, $avgCost, $currency, $baseCurrency, $date);
+            $lastPriceBase = fx_convert($this->pdo, $lastPrice, $currency, $baseCurrency, $date);
+            $marketValue = $qty * $lastPrice;
+            $marketValueBase = $qty * $lastPriceBase;
+            $totalCostBasePosition = fx_convert($this->pdo, $avgCost * $qty, $currency, $baseCurrency, $date);
+            $unrealizedBase = fx_convert($this->pdo, ($lastPrice - $avgCost) * $qty, $currency, $baseCurrency, $date);
+            $unrealizedPercent = $avgCost > 0 ? (($lastPrice - $avgCost) / $avgCost) * 100.0 : 0.0;
+            $dayChange = $quote ? ($quote->last - $quote->previousClose) * $qty : 0.0;
+            $dayChangeBase = $quote ? fx_convert($this->pdo, $dayChange, $currency, $baseCurrency, $date) : 0.0;
+
+            $holdingTemp[] = [
+                'stock_id' => $stockId,
+                'symbol' => $symbol,
+                'exchange' => $exchange,
+                'name' => $name,
+                'currency' => $currency,
+                'qty' => $qty,
+                'avg_cost' => $avgCost,
+                'avg_cost_base' => $avgCostBase,
+                'last_price' => $lastPrice,
+                'last_price_base' => $lastPriceBase,
+                'market_value' => $marketValue,
+                'market_value_base' => $marketValueBase,
+                'unrealized' => $unrealizedBase,
+                'unrealized_percent' => $unrealizedPercent,
+                'day_change' => $dayChange,
+                'day_change_base' => $dayChangeBase,
+                'sector' => $sector,
+                'industry' => $industry,
+                'quote' => $quote,
+            ];
+
+            $totalMarketValueBase += $marketValueBase;
+            $totalCostBase += $totalCostBasePosition;
+            $unrealizedBaseTotal += $unrealizedBase;
+            $dailyPLBase += $dayChangeBase;
+
+            $allocTicker[$symbol] = ($allocTicker[$symbol] ?? 0.0) + $marketValueBase;
+            $sectorKey = $sector ?: 'Unclassified';
+            $allocSector[$sectorKey] = ($allocSector[$sectorKey] ?? 0.0) + $marketValueBase;
+            $allocCurrency[$currency] = ($allocCurrency[$currency] ?? 0.0) + $marketValueBase;
+        }
+
+        $holdings = [];
+        foreach ($holdingTemp as $row) {
+            $weight = $totalMarketValueBase > 0 ? ($row['market_value_base'] / $totalMarketValueBase) : 0.0;
+            $concentration = $weight >= 0.15;
+            $holdings[] = new Holding(
+                $row['stock_id'],
+                $row['symbol'],
+                $row['exchange'],
+                $row['name'],
+                $row['currency'],
+                $row['qty'],
+                $row['avg_cost'],
+                $row['avg_cost_base'],
+                $baseCurrency,
+                $row['last_price'],
+                $row['last_price_base'],
+                $row['market_value'],
+                $row['market_value_base'],
+                $row['unrealized'],
+                $row['unrealized_percent'],
+                $row['day_change'],
+                $row['day_change_base'],
+                $weight * 100.0,
+                $row['sector'],
+                $row['industry'],
+                null,
+                $concentration,
+            );
+        }
+
+        $allocationsByTicker = $this->buildAllocationSlices($allocTicker, $totalMarketValueBase);
+        $allocationsBySector = $this->buildAllocationSlices($allocSector, $totalMarketValueBase);
+        $allocationsByCurrency = $this->buildAllocationSlices($allocCurrency, $totalMarketValueBase);
+
+        $watchEntries = [];
+        foreach ($watchStocks as $row) {
+            $stockId = (int) $row['id'];
+            $quote = $quotes[$stockId] ?? null;
+            $watchEntries[] = new WatchlistEntry(
+                $stockId,
+                (string) $row['symbol'],
+                (string) $row['name'],
+                (string) $row['exchange'],
+                strtoupper((string) $row['currency']),
+                $quote
+            );
+        }
+
+        $cashImpact = $this->calculateCashImpact($userId, $baseCurrency);
+        $realized = $this->trades->sumRealized($userId, $from, $to);
+        $unrealizedPercent = $totalCostBase > 0 ? ($unrealizedBaseTotal / $totalCostBase) * 100.0 : 0.0;
+
+        $snapshot = new PortfolioSnapshot(
+            $baseCurrency,
+            $totalMarketValueBase,
+            $totalCostBase,
+            $unrealizedBaseTotal,
+            $unrealizedPercent,
+            $realized,
+            $cashImpact,
+            $dailyPLBase,
+            $holdings,
+            $watchEntries,
+            $allocationsByTicker,
+            $allocationsBySector,
+            $allocationsByCurrency,
+            []
+        );
+
+        $insights = $this->signals->portfolioInsights($userId, $snapshot);
+
+        return new PortfolioSnapshot(
+            $snapshot->baseCurrency,
+            $snapshot->totalMarketValue,
+            $snapshot->totalCost,
+            $snapshot->unrealized,
+            $snapshot->unrealizedPercent,
+            $snapshot->realizedPeriod,
+            $snapshot->cashImpact,
+            $snapshot->dailyPL,
+            $snapshot->holdings,
+            $snapshot->watchlist,
+            $snapshot->allocationsByTicker,
+            $snapshot->allocationsBySector,
+            $snapshot->allocationsByCurrency,
+            $insights
+        );
+    }
+
+    /**
+     * @return list<AllocationSlice>
+     */
+    private function buildAllocationSlices(array $map, float $total): array
+    {
+        $slices = [];
+        foreach ($map as $label => $value) {
+            $weight = $total > 0 ? ($value / $total) * 100.0 : 0.0;
+            $slices[] = new AllocationSlice((string) $label, (float) $value, $weight);
+        }
+        usort($slices, static fn (AllocationSlice $a, AllocationSlice $b): int => $b->weight <=> $a->weight);
+        return $slices;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $holdings
+     * @return array<int, array<string, mixed>>
+     */
+    private function filterHoldings(array $holdings, array $filters, array $watchIds): array
+    {
+        if ($filters === []) {
+            return $holdings;
+        }
+
+        $search = isset($filters['search']) ? strtolower((string) $filters['search']) : null;
+        $currency = isset($filters['currency']) ? strtoupper((string) $filters['currency']) : null;
+        $sector = isset($filters['sector']) ? strtolower((string) $filters['sector']) : null;
+        $watchOnly = !empty($filters['watchlist']);
+
+        return array_values(array_filter($holdings, static function (array $row) use ($search, $currency, $sector, $watchOnly, $watchIds): bool {
+            if ($search) {
+                $hay = strtolower((string) $row['symbol'] . ' ' . (string) $row['name']);
+                if (!str_contains($hay, $search)) {
+                    return false;
+                }
+            }
+            if ($currency && strtoupper((string) $row['currency']) !== $currency) {
+                return false;
+            }
+            if ($sector) {
+                $rowSector = strtolower((string) ($row['sector'] ?? ''));
+                if ($rowSector === '' || !str_contains($rowSector, $sector)) {
+                    return false;
+                }
+            }
+            if ($watchOnly && !in_array((int) $row['stock_id'], $watchIds, true)) {
+                return false;
+            }
+            return true;
+        }));
+    }
+
+    /**
+     * @return array{0: ?DateTimeImmutable, 1: ?DateTimeImmutable}
+     */
+    private function rangeToDates(string $range): array
+    {
+        $range = strtoupper($range);
+        $to = new DateTimeImmutable();
+        return match ($range) {
+            '1W' => [$to->sub(new DateInterval('P7D')), $to],
+            '1M' => [$to->sub(new DateInterval('P1M')), $to],
+            '3M' => [$to->sub(new DateInterval('P3M')), $to],
+            '6M' => [$to->sub(new DateInterval('P6M')), $to],
+            '1Y' => [$to->sub(new DateInterval('P1Y')), $to],
+            'YTD' => [new DateTimeImmutable($to->format('Y-01-01')), $to],
+            default => [$to->sub(new DateInterval('P1M')), $to],
+        };
+    }
+
+    private function calculateCashImpact(int $userId, string $baseCurrency): float
+    {
+        $trades = $this->trades->allTrades($userId);
+        $impact = 0.0;
+        foreach ($trades as $trade) {
+            $side = strtoupper((string) $trade['side']);
+            $qty = (float) $trade['qty'];
+            $price = (float) $trade['price'];
+            $fee = (float) $trade['fee'];
+            $currency = strtoupper((string) $trade['currency']);
+            $date = (new DateTimeImmutable((string) $trade['executed_at']))->format('Y-m-d');
+
+            if ($side === 'BUY') {
+                $flow = -($qty * $price + $fee);
+            } elseif ($side === 'SELL') {
+                $flow = ($qty * $price) - $fee;
+            } else {
+                continue;
+            }
+            $impact += fx_convert($this->pdo, $flow, $currency, $baseCurrency, $date);
+        }
+        return $impact;
+    }
+}

--- a/src/Stocks/Services/PriceDataService.php
+++ b/src/Stocks/Services/PriceDataService.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\Services;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeInterface;
+use MyMoneyMap\Stocks\Adapters\PriceProviderAdapter;
+use MyMoneyMap\Stocks\DTO\LiveQuote;
+use MyMoneyMap\Stocks\DTO\QuoteHistory;
+use MyMoneyMap\Stocks\DTO\QuoteHistoryPoint;
+use MyMoneyMap\Stocks\Repositories\PriceRepository;
+
+final class PriceDataService
+{
+    /** @var array<string, array{quote: LiveQuote, expires: DateTimeImmutable}> */
+    private array $memoryCache = [];
+
+    public function __construct(
+        private readonly PriceRepository $prices,
+        private readonly PriceProviderAdapter $adapter,
+        private readonly int $cacheTtlSeconds = 8,
+    ) {
+    }
+
+    /**
+     * @param list<array{stock_id:int,symbol:string,exchange:string}> $requests
+     * @return array<int, LiveQuote>
+     */
+    public function getLiveQuotes(array $requests): array
+    {
+        $now = new DateTimeImmutable();
+        $result = [];
+        $needFetch = [];
+
+        foreach ($requests as $request) {
+            $symbol = strtoupper($request['symbol']);
+            $exchange = strtoupper($request['exchange']);
+            $key = $this->key($symbol, $exchange);
+
+            if (isset($this->memoryCache[$key]) && $this->memoryCache[$key]['expires'] > $now) {
+                $result[$request['stock_id']] = $this->memoryCache[$key]['quote'];
+                continue;
+            }
+
+            $db = $this->prices->lastPrice($request['stock_id']);
+            if ($db) {
+                $quote = $this->fromRow($symbol, $db);
+                $result[$request['stock_id']] = $quote;
+                $this->memoryCache[$key] = [
+                    'quote' => $quote,
+                    'expires' => $now->add(new DateInterval('PT' . $this->cacheTtlSeconds . 'S')),
+                ];
+            }
+
+            $needFetch[$key] = $symbol;
+        }
+
+        if ($needFetch !== []) {
+            $fetched = $this->adapter->fetchLiveQuotes(array_values(array_unique($needFetch)));
+            foreach ($requests as $request) {
+                $symbol = strtoupper($request['symbol']);
+                $exchange = strtoupper($request['exchange']);
+                $key = $this->key($symbol, $exchange);
+                $quote = $fetched[$symbol] ?? null;
+                if (!$quote) {
+                    continue;
+                }
+
+                $result[$request['stock_id']] = $quote;
+                $this->memoryCache[$key] = [
+                    'quote' => $quote,
+                    'expires' => $now->add(new DateInterval('PT' . $this->cacheTtlSeconds . 'S')),
+                ];
+
+                $this->prices->upsertLastPrice($request['stock_id'], [
+                    'last' => $quote->last,
+                    'prev_close' => $quote->previousClose,
+                    'day_high' => $quote->dayHigh,
+                    'day_low' => $quote->dayLow,
+                    'volume' => $quote->volume,
+                    'provider_ts' => $quote->asOf->format('c'),
+                ]);
+            }
+        }
+
+        return $result;
+    }
+
+    public function getDailyHistory(int $stockId, string $symbol, DateTimeInterface $from, DateTimeInterface $to): QuoteHistory
+    {
+        $rows = $this->prices->dailySeries($stockId, DateTimeImmutable::createFromInterface($from), DateTimeImmutable::createFromInterface($to));
+        $points = [];
+        foreach ($rows as $row) {
+            $points[] = new QuoteHistoryPoint(
+                new DateTimeImmutable($row['date']),
+                (float) $row['open'],
+                (float) $row['high'],
+                (float) $row['low'],
+                (float) $row['close'],
+                (float) $row['volume'],
+                false
+            );
+        }
+
+        $history = new QuoteHistory(
+            $points,
+            DateTimeImmutable::createFromInterface($from),
+            DateTimeImmutable::createFromInterface($to)
+        );
+
+        if ($history->isEmpty()) {
+            $fetched = $this->adapter->fetchDailyHistory($symbol, $from, $to);
+            foreach ($fetched as $point) {
+                $this->prices->insertDailyPrice($stockId, $point->date, [
+                    'open' => $point->open,
+                    'high' => $point->high,
+                    'low' => $point->low,
+                    'close' => $point->close,
+                    'volume' => $point->volume,
+                ]);
+            }
+            return $fetched;
+        }
+
+        return $history->fillGaps();
+    }
+
+    private function key(string $symbol, string $exchange): string
+    {
+        return $symbol . '@' . $exchange;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function fromRow(string $symbol, array $row): LiveQuote
+    {
+        $updated = isset($row['provider_ts']) ? new DateTimeImmutable((string) $row['provider_ts']) : new DateTimeImmutable('-1 day');
+        $stale = $updated < (new DateTimeImmutable('-15 minutes'));
+
+        return new LiveQuote(
+            $symbol,
+            (float) ($row['last'] ?? 0),
+            (float) ($row['prev_close'] ?? 0),
+            (float) ($row['day_high'] ?? 0),
+            (float) ($row['day_low'] ?? 0),
+            (float) ($row['volume'] ?? 0),
+            $updated,
+            $stale,
+        );
+    }
+}

--- a/src/Stocks/Services/SignalsService.php
+++ b/src/Stocks/Services/SignalsService.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\Services;
+
+use DateInterval;
+use DateTimeImmutable;
+use MyMoneyMap\Stocks\DTO\Holding;
+use MyMoneyMap\Stocks\DTO\Insight;
+use MyMoneyMap\Stocks\DTO\PortfolioSnapshot;
+use MyMoneyMap\Stocks\DTO\QuoteHistoryPoint;
+use MyMoneyMap\Stocks\Repositories\SettingsRepository;
+use PDO;
+
+final class SignalsService
+{
+    public function __construct(
+        private readonly PDO $pdo,
+        private readonly PriceDataService $prices,
+        private readonly SettingsRepository $settings,
+    ) {
+    }
+
+    /**
+     * @return list<Insight>
+     */
+    public function portfolioInsights(int $userId, PortfolioSnapshot $snapshot): array
+    {
+        $insights = [];
+        $total = $snapshot->totalMarketValue;
+        $settings = $this->settings->userSettings($userId);
+        $targetAlloc = $this->decodeTargetAllocations($settings['target_allocations'] ?? null);
+
+        foreach ($snapshot->holdings as $holding) {
+            if ($holding->concentrationWarning) {
+                $insights[] = new Insight(
+                    sprintf('Concentration: %s', $holding->symbol),
+                    sprintf('%s is %.1f%% of equity — consider trimming or diversifying.', $holding->symbol, $holding->weight),
+                    'warning'
+                );
+            }
+            $target = $targetAlloc[$holding->symbol] ?? null;
+            if ($target !== null && $holding->weight > $target + 5.0) {
+                $insights[] = new Insight(
+                    sprintf('Over target: %s', $holding->symbol),
+                    sprintf('Current weight %.1f%% exceeds target %.1f%%.', $holding->weight, $target),
+                    'info'
+                );
+            }
+        }
+
+        if ($total > 0 && abs($snapshot->dailyPL / max($total, 1)) > 0.02) {
+            $insights[] = new Insight(
+                'Elevated daily P/L',
+                sprintf('Daily change %.2f %s (%.2f%%). Consider reviewing exposures.', $snapshot->dailyPL, $snapshot->baseCurrency, ($snapshot->dailyPL / $total) * 100),
+                'info'
+            );
+        }
+
+        return $insights;
+    }
+
+    /**
+     * @return list<Insight>
+     */
+    public function positionInsights(int $userId, Holding $holding): array
+    {
+        $settings = $this->settings->userSettings($userId);
+        $targetAlloc = $this->decodeTargetAllocations($settings['target_allocations'] ?? null);
+        $targetWeight = $targetAlloc[$holding->symbol] ?? null;
+
+        $today = new DateTimeImmutable();
+        $from = $today->sub(new DateInterval('P120D'));
+        $history = $this->prices->getDailyHistory($holding->stockId, $holding->symbol, $from, $today);
+        $closes = array_map(static fn (QuoteHistoryPoint $point): float => $point->close, iterator_to_array($history));
+        $indicators = $this->computeIndicators($closes);
+
+        $insights = [];
+
+        if ($indicators['sma20'] !== null && $indicators['sma50'] !== null) {
+            $trendUp = $holding->lastPrice > $indicators['sma50'];
+            $momentumText = $trendUp ? 'above' : 'below';
+            $insights[] = new Insight(
+                'Momentum',
+                sprintf('Price is %s the 50D SMA (%.2f vs %.2f).', $momentumText, $holding->lastPrice, $indicators['sma50']),
+                $trendUp ? 'success' : 'warning'
+            );
+            if ($trendUp && $targetWeight !== null && $holding->weight < $targetWeight - 2.0) {
+                $insights[] = new Insight(
+                    'Potential add',
+                    sprintf('Trend is up and weight %.1f%% is below target %.1f%%.', $holding->weight, $targetWeight),
+                    'info'
+                );
+            }
+        }
+
+        if ($targetWeight !== null && $holding->weight > $targetWeight + 3.0) {
+            $insights[] = new Insight(
+                'Trim candidate',
+                sprintf('Weight %.1f%% exceeds target %.1f%% — consider partial trim.', $holding->weight, $targetWeight),
+                'warning'
+            );
+        }
+
+        if ($indicators['rsi'] !== null) {
+            if ($indicators['rsi'] > 70) {
+                $insights[] = new Insight(
+                    'Overbought',
+                    sprintf('RSI(14) %.1f > 70; consider tightening stops or trimming.', $indicators['rsi']),
+                    'warning'
+                );
+            } elseif ($indicators['rsi'] < 35) {
+                $insights[] = new Insight(
+                    'Oversold watch',
+                    sprintf('RSI(14) %.1f — monitor for reversal signals.', $indicators['rsi']),
+                    'info'
+                );
+            }
+        }
+
+        if ($indicators['swingHigh']) {
+            $insights[] = new Insight(
+                'Consider stop update',
+                'New swing high detected — review stop levels to lock gains.',
+                'info'
+            );
+        } elseif ($indicators['swingLow']) {
+            $insights[] = new Insight(
+                'Watch only',
+                'Recent swing low suggests caution; wait for confirmation before adding.',
+                'warning'
+            );
+        }
+
+        $distance = $holding->averageCost > 0 ? (($holding->lastPrice - $holding->averageCost) / $holding->averageCost) * 100.0 : 0.0;
+        $insights[] = new Insight(
+            'Position health',
+            sprintf('Current price is %.1f%% %s average cost.', abs($distance), $distance >= 0 ? 'above' : 'below'),
+            $distance >= 0 ? 'success' : 'warning'
+        );
+
+        return $insights;
+    }
+
+    /**
+     * @return array{rsi: ?float, sma20: ?float, sma50: ?float, swingHigh: bool, swingLow: bool}
+     */
+    private function computeIndicators(array $closes): array
+    {
+        $count = count($closes);
+        $sma20 = $count >= 20 ? array_sum(array_slice($closes, -20)) / 20.0 : null;
+        $sma50 = $count >= 50 ? array_sum(array_slice($closes, -50)) / 50.0 : null;
+        $rsi = $this->calculateRsi($closes, 14);
+
+        $recent = $count >= 20 ? array_slice($closes, -20) : $closes;
+        $last = $closes !== [] ? $closes[$count - 1] : null;
+        $swingHigh = $last !== null && $recent !== [] && $last >= max($recent);
+        $swingLow = $last !== null && $recent !== [] && $last <= min($recent);
+
+        return [
+            'rsi' => $rsi,
+            'sma20' => $sma20,
+            'sma50' => $sma50,
+            'swingHigh' => $swingHigh,
+            'swingLow' => $swingLow,
+        ];
+    }
+
+    private function calculateRsi(array $closes, int $period): ?float
+    {
+        $count = count($closes);
+        if ($count <= $period) {
+            return null;
+        }
+        $gains = 0.0;
+        $losses = 0.0;
+        for ($i = $count - $period; $i < $count; $i++) {
+            if ($i === 0) {
+                continue;
+            }
+            $change = $closes[$i] - $closes[$i - 1];
+            if ($change >= 0) {
+                $gains += $change;
+            } else {
+                $losses += abs($change);
+            }
+        }
+        if ($losses == 0.0) {
+            return 100.0;
+        }
+        $rs = ($gains / $period) / ($losses / $period);
+        return 100.0 - (100.0 / (1.0 + $rs));
+    }
+
+    /**
+     * @return array<string, float>
+     */
+    private function decodeTargetAllocations(?string $json): array
+    {
+        if (!$json) {
+            return [];
+        }
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+        $map = [];
+        foreach ($decoded as $symbol => $weight) {
+            if (!is_numeric($weight)) {
+                continue;
+            }
+            $map[strtoupper((string) $symbol)] = (float) $weight;
+        }
+        return $map;
+    }
+}

--- a/src/Stocks/Services/TradeService.php
+++ b/src/Stocks/Services/TradeService.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyMoneyMap\Stocks\Services;
+
+use DateTimeImmutable;
+use MyMoneyMap\Stocks\DTO\TradeInput;
+use MyMoneyMap\Stocks\DTO\TradeResult;
+use MyMoneyMap\Stocks\Repositories\SettingsRepository;
+use MyMoneyMap\Stocks\Repositories\StockRepository;
+use MyMoneyMap\Stocks\Repositories\TradeRepository;
+use PDO;
+use RuntimeException;
+use Throwable;
+
+use function fx_convert;
+use function fx_user_main;
+
+final class TradeService
+{
+    public function __construct(
+        private readonly PDO $pdo,
+        private readonly StockRepository $stocks,
+        private readonly TradeRepository $trades,
+        private readonly SettingsRepository $settings,
+    ) {
+    }
+
+    public function recordTrade(TradeInput $input): TradeResult
+    {
+        if ($input->quantity <= 0) {
+            return new TradeResult(false, null, 'Quantity must be positive.');
+        }
+        if ($input->price <= 0) {
+            return new TradeResult(false, null, 'Price must be positive.');
+        }
+
+        $symbol = strtoupper($input->symbol);
+        $exchange = strtoupper($input->exchange);
+        $currency = strtoupper($input->currency);
+
+        $this->pdo->beginTransaction();
+        try {
+            $stockId = $this->stocks->upsert([
+                'symbol' => $symbol,
+                'exchange' => $exchange,
+                'name' => $input->name,
+                'currency' => $currency,
+            ]);
+
+            $tradeId = $this->trades->insertTrade(
+                $input->userId,
+                $stockId,
+                strtoupper($input->side),
+                $input->quantity,
+                $input->price,
+                $input->fee,
+                $currency,
+                $input->executedAt,
+                $input->note
+            );
+
+            $this->rebuildPosition($input->userId, $stockId);
+
+            $this->pdo->commit();
+            return new TradeResult(true, $tradeId, null);
+        } catch (Throwable $e) {
+            $this->pdo->rollBack();
+            return new TradeResult(false, null, $e->getMessage());
+        }
+    }
+
+    public function deleteTrade(int $userId, int $tradeId): void
+    {
+        $row = $this->pdo->prepare('SELECT stock_id FROM stock_trades WHERE id = ? AND user_id = ?');
+        $row->execute([$tradeId, $userId]);
+        $stockId = $row->fetchColumn();
+        if ($stockId === false) {
+            return;
+        }
+
+        $this->pdo->beginTransaction();
+        try {
+            $this->trades->deleteTrade($userId, $tradeId);
+            $this->rebuildPosition($userId, (int) $stockId);
+            $this->pdo->commit();
+        } catch (Throwable $e) {
+            $this->pdo->rollBack();
+            throw $e;
+        }
+    }
+
+    private function rebuildPosition(int $userId, int $stockId): void
+    {
+        $trades = $this->trades->tradesForStock($userId, $stockId);
+        $position = $this->trades->findPosition($userId, $stockId);
+        $currency = $position['avg_cost_currency'] ?? ($trades[0]['currency'] ?? 'USD');
+
+        if ($position) {
+            $positionId = (int) $position['id'];
+        } else {
+            $positionId = $this->trades->upsertPosition($userId, $stockId, 0.0, 0.0, $currency);
+            $position = $this->trades->findPosition($userId, $stockId);
+        }
+
+        if ($positionId <= 0) {
+            throw new RuntimeException('Could not resolve stock position.');
+        }
+
+        $this->trades->deleteLots($positionId);
+        $this->trades->deleteRealized($userId, $stockId);
+
+        $openLots = [];
+        $qty = 0.0;
+        $totalCost = 0.0;
+        $baseCurrency = fx_user_main($this->pdo, $userId);
+
+        foreach ($trades as $trade) {
+            $side = strtoupper((string) $trade['side']);
+            $tradeQty = (float) $trade['qty'];
+            $tradePrice = (float) $trade['price'];
+            $tradeFee = (float) $trade['fee'];
+            $tradeCurrency = strtoupper((string) $trade['currency']);
+            $executedAt = new DateTimeImmutable((string) $trade['executed_at']);
+            $currency = $tradeCurrency;
+
+            if ($side === 'BUY') {
+                $lotId = $this->trades->createLot($positionId, $tradeQty, $tradePrice, $tradeFee, $tradeCurrency, $executedAt);
+                $openLots[] = [
+                    'id' => $lotId,
+                    'qty' => $tradeQty,
+                    'used' => 0.0,
+                    'price' => $tradePrice,
+                    'fee' => $tradeFee,
+                ];
+                $qty += $tradeQty;
+                $totalCost += $tradeQty * $tradePrice + $tradeFee;
+                continue;
+            }
+
+            if ($side !== 'SELL') {
+                continue;
+            }
+
+            $available = 0.0;
+            foreach ($openLots as $lot) {
+                $available += max(0.0, $lot['qty'] - $lot['used']);
+            }
+            if ($tradeQty - $available > 1e-6) {
+                throw new RuntimeException('Sell quantity exceeds available shares.');
+            }
+
+            $remaining = $tradeQty;
+            $costConsumed = 0.0;
+            foreach ($openLots as $index => $lot) {
+                $lotRemaining = max(0.0, $lot['qty'] - $lot['used']);
+                if ($lotRemaining <= 0.0) {
+                    continue;
+                }
+                $take = min($remaining, $lotRemaining);
+                if ($take <= 0.0) {
+                    continue;
+                }
+                $feePerShare = $lot['qty'] > 0 ? $lot['fee'] / $lot['qty'] : 0.0;
+                $costPerShare = $lot['price'] + $feePerShare;
+                $costConsumed += $costPerShare * $take;
+                $openLots[$index]['used'] += $take;
+                $this->trades->closeLotPartial($lot['id'], $take, $openLots[$index]['used'] >= $lot['qty'] - 1e-6, $executedAt);
+                $remaining -= $take;
+                if ($remaining <= 0.0) {
+                    break;
+                }
+            }
+
+            $proceeds = $tradeQty * $tradePrice - $tradeFee;
+            $realizedCcy = $proceeds - $costConsumed;
+            $realizedBase = fx_convert($this->pdo, $realizedCcy, $tradeCurrency, $baseCurrency, $executedAt->format('Y-m-d'));
+            $this->trades->persistRealized($userId, $stockId, (int) $trade['id'], $realizedBase, $realizedCcy, 'FIFO');
+
+            $qty -= $tradeQty;
+            $totalCost -= $costConsumed;
+        }
+
+        if ($qty <= 1e-6) {
+            $qty = 0.0;
+            $totalCost = 0.0;
+        }
+        $avgCost = $qty > 0 ? $totalCost / $qty : 0.0;
+        $this->trades->upsertPosition($userId, $stockId, $qty, $avgCost, $currency);
+    }
+}

--- a/tests/stocks_tests.php
+++ b/tests/stocks_tests.php
@@ -1,0 +1,348 @@
+<?php
+
+declare(strict_types=1);
+
+date_default_timezone_set('UTC');
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'MyMoneyMap\\';
+    if (!str_starts_with($class, $prefix)) {
+        return;
+    }
+    $relative = substr($class, strlen($prefix));
+    $path = __DIR__ . '/../src/' . str_replace('\\', '/', $relative) . '.php';
+    if (is_file($path)) {
+        require $path;
+    }
+});
+
+require __DIR__ . '/../src/fx.php';
+
+use MyMoneyMap\Stocks\Adapters\PriceProviderAdapter;
+use MyMoneyMap\Stocks\DTO\Holding;
+use MyMoneyMap\Stocks\DTO\LiveQuote;
+use MyMoneyMap\Stocks\DTO\QuoteHistory;
+use MyMoneyMap\Stocks\DTO\TradeInput;
+use MyMoneyMap\Stocks\Repositories\PriceRepository;
+use MyMoneyMap\Stocks\Repositories\SettingsRepository;
+use MyMoneyMap\Stocks\Repositories\StockRepository;
+use MyMoneyMap\Stocks\Repositories\TradeRepository;
+use MyMoneyMap\Stocks\Services\ChartsService;
+use MyMoneyMap\Stocks\Services\PortfolioService;
+use MyMoneyMap\Stocks\Services\PriceDataService;
+use MyMoneyMap\Stocks\Services\SignalsService;
+use MyMoneyMap\Stocks\Services\TradeService;
+
+final class TestPriceAdapter implements PriceProviderAdapter
+{
+    /** @var array<string, LiveQuote> */
+    public array $quotes = [];
+
+    /** @var array<string, QuoteHistory> */
+    public array $history = [];
+
+    /**
+     * @param array<int, string> $symbols
+     * @return array<string, LiveQuote>
+     */
+    public function fetchLiveQuotes(array $symbols): array
+    {
+        $out = [];
+        $now = new DateTimeImmutable();
+        foreach ($symbols as $symbol) {
+            $symbol = strtoupper($symbol);
+            $out[$symbol] = $this->quotes[$symbol] ?? new LiveQuote($symbol, 0.0, 0.0, 0.0, 0.0, 0.0, $now, true);
+        }
+        return $out;
+    }
+
+    public function fetchDailyHistory(string $symbol, \DateTimeInterface $from, \DateTimeInterface $to): QuoteHistory
+    {
+        $symbol = strtoupper($symbol);
+        if (isset($this->history[$symbol])) {
+            return $this->history[$symbol];
+        }
+        return new QuoteHistory([], DateTimeImmutable::createFromInterface($from), DateTimeImmutable::createFromInterface($to));
+    }
+}
+
+final class TestContext
+{
+    public function __construct(
+        public PDO $pdo,
+        public StockRepository $stocks,
+        public TradeRepository $trades,
+        public SettingsRepository $settings,
+        public PriceRepository $prices,
+        public TestPriceAdapter $adapter,
+        public PriceDataService $priceService,
+        public SignalsService $signals,
+        public PortfolioService $portfolio,
+        public TradeService $tradeService,
+        public ChartsService $charts,
+    ) {
+    }
+}
+
+/**
+ * @return TestContext
+ */
+function create_context(): TestContext
+{
+    $pdo = new PDO('sqlite::memory:');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+    $pdo->exec('PRAGMA foreign_keys = ON');
+
+    create_schema($pdo);
+    seed_user($pdo, 1, 'Test User', 'USD');
+
+    $priceRepo = new PriceRepository($pdo);
+    $stockRepo = new StockRepository($pdo);
+    $tradeRepo = new TradeRepository($pdo);
+    $settingsRepo = new SettingsRepository($pdo);
+    $adapter = new TestPriceAdapter();
+    $priceService = new PriceDataService($priceRepo, $adapter, 1);
+    $signals = new SignalsService($pdo, $priceService, $settingsRepo);
+    $portfolio = new PortfolioService($pdo, $tradeRepo, $stockRepo, $settingsRepo, $priceService, $signals);
+    $tradeService = new TradeService($pdo, $stockRepo, $tradeRepo, $settingsRepo);
+    $charts = new ChartsService($pdo, $tradeRepo, $priceService);
+
+    return new TestContext($pdo, $stockRepo, $tradeRepo, $settingsRepo, $priceRepo, $adapter, $priceService, $signals, $portfolio, $tradeService, $charts);
+}
+
+function create_schema(PDO $pdo): void
+{
+    $stmts = [
+        'CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)',
+        'CREATE TABLE user_currencies (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL, code TEXT NOT NULL, is_main INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(user_id) REFERENCES users(id))',
+        'CREATE TABLE stocks (id INTEGER PRIMARY KEY AUTOINCREMENT, symbol TEXT NOT NULL, exchange TEXT NOT NULL, name TEXT, currency TEXT NOT NULL, sector TEXT, industry TEXT, created_at TEXT DEFAULT CURRENT_TIMESTAMP, updated_at TEXT DEFAULT CURRENT_TIMESTAMP, UNIQUE(symbol, exchange))',
+        'CREATE TABLE stock_positions (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL, stock_id INTEGER NOT NULL, qty REAL NOT NULL DEFAULT 0, avg_cost_ccy REAL NOT NULL DEFAULT 0, avg_cost_currency TEXT NOT NULL DEFAULT "USD", created_at TEXT DEFAULT CURRENT_TIMESTAMP, updated_at TEXT DEFAULT CURRENT_TIMESTAMP, UNIQUE(user_id, stock_id), FOREIGN KEY(user_id) REFERENCES users(id), FOREIGN KEY(stock_id) REFERENCES stocks(id))',
+        'CREATE TABLE stock_trades (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL, stock_id INTEGER NOT NULL, side TEXT NOT NULL, qty REAL NOT NULL, price REAL NOT NULL, fee REAL NOT NULL DEFAULT 0, currency TEXT NOT NULL, executed_at TEXT NOT NULL, note TEXT, created_at TEXT DEFAULT CURRENT_TIMESTAMP, updated_at TEXT DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY(user_id) REFERENCES users(id), FOREIGN KEY(stock_id) REFERENCES stocks(id))',
+        'CREATE TABLE stock_lots (id INTEGER PRIMARY KEY AUTOINCREMENT, position_id INTEGER NOT NULL, qty_open REAL NOT NULL, qty_closed REAL NOT NULL DEFAULT 0, open_price REAL NOT NULL, fee REAL NOT NULL DEFAULT 0, currency TEXT NOT NULL, opened_at TEXT NOT NULL, closed_at TEXT, created_at TEXT DEFAULT CURRENT_TIMESTAMP, updated_at TEXT DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY(position_id) REFERENCES stock_positions(id))',
+        'CREATE TABLE stock_realized_pl (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL, stock_id INTEGER NOT NULL, sell_trade_id INTEGER, realized_pl_base REAL NOT NULL DEFAULT 0, realized_pl_ccy REAL NOT NULL DEFAULT 0, method TEXT NOT NULL, created_at TEXT DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY(user_id) REFERENCES users(id), FOREIGN KEY(stock_id) REFERENCES stocks(id))',
+        'CREATE TABLE watchlist (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL, stock_id INTEGER NOT NULL, created_at TEXT DEFAULT CURRENT_TIMESTAMP, UNIQUE(user_id, stock_id))',
+        'CREATE TABLE user_settings_stocks (user_id INTEGER PRIMARY KEY, cost_basis_unrealized TEXT NOT NULL DEFAULT "AVERAGE", realized_method TEXT NOT NULL DEFAULT "FIFO", target_allocations TEXT, FOREIGN KEY(user_id) REFERENCES users(id))',
+        'CREATE TABLE stock_prices_last (stock_id INTEGER PRIMARY KEY, last REAL NOT NULL DEFAULT 0, prev_close REAL NOT NULL DEFAULT 0, day_high REAL NOT NULL DEFAULT 0, day_low REAL NOT NULL DEFAULT 0, volume REAL NOT NULL DEFAULT 0, provider_ts TEXT, updated_at TEXT DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY(stock_id) REFERENCES stocks(id))',
+        'CREATE TABLE price_daily (id INTEGER PRIMARY KEY AUTOINCREMENT, stock_id INTEGER NOT NULL, date TEXT NOT NULL, open REAL NOT NULL DEFAULT 0, high REAL NOT NULL DEFAULT 0, low REAL NOT NULL DEFAULT 0, close REAL NOT NULL DEFAULT 0, volume REAL NOT NULL DEFAULT 0, provider TEXT, created_at TEXT DEFAULT CURRENT_TIMESTAMP, updated_at TEXT DEFAULT CURRENT_TIMESTAMP, UNIQUE(stock_id, date), FOREIGN KEY(stock_id) REFERENCES stocks(id))',
+        'CREATE TABLE fx_rates (rate_date TEXT NOT NULL, base_code TEXT NOT NULL, code TEXT NOT NULL, rate REAL NOT NULL, PRIMARY KEY(rate_date, base_code, code))',
+    ];
+    foreach ($stmts as $sql) {
+        $pdo->exec($sql);
+    }
+}
+
+function seed_user(PDO $pdo, int $userId, string $name, string $currency): void
+{
+    $pdo->prepare('INSERT INTO users(id, name) VALUES (?, ?)')->execute([$userId, $name]);
+    $pdo->prepare('INSERT INTO user_currencies(user_id, code, is_main) VALUES (?, ?, 1)')->execute([$userId, strtoupper($currency)]);
+}
+
+function assert_true(bool $condition, string $message = 'Assertion failed'): void
+{
+    if (!$condition) {
+        throw new AssertionError($message);
+    }
+}
+
+function assert_equals(mixed $expected, mixed $actual, string $message = ''): void
+{
+    if ($expected !== $actual) {
+        $msg = $message !== '' ? $message : sprintf('Expected %s but got %s', var_export($expected, true), var_export($actual, true));
+        throw new AssertionError($msg);
+    }
+}
+
+function assert_float(float $expected, float $actual, float $delta = 0.0001, string $message = ''): void
+{
+    if (abs($expected - $actual) > $delta) {
+        $msg = $message !== '' ? $message : sprintf('Expected %.4f but got %.4f', $expected, $actual);
+        throw new AssertionError($msg);
+    }
+}
+
+/** @var list<array{string, callable}> $tests */
+$tests = [];
+
+function test(string $name, callable $fn): void
+{
+    global $tests;
+    $tests[] = [$name, $fn];
+}
+
+test('FIFO realized P/L and remaining lot averages', function (): void {
+    $ctx = create_context();
+    $userId = 1;
+    $date1 = new DateTimeImmutable('2023-01-02 10:00:00');
+    $date2 = new DateTimeImmutable('2023-01-10 10:00:00');
+    $date3 = new DateTimeImmutable('2023-02-01 09:30:00');
+
+    $res1 = $ctx->tradeService->recordTrade(new TradeInput($userId, 'FIFO', 'NYSE', 'FIFO Corp', 'USD', 'BUY', 100, 10.0, 1.0, $date1));
+    assert_true($res1->success, 'First buy failed');
+    $res2 = $ctx->tradeService->recordTrade(new TradeInput($userId, 'FIFO', 'NYSE', 'FIFO Corp', 'USD', 'BUY', 50, 12.0, 1.0, $date2));
+    assert_true($res2->success, 'Second buy failed');
+    $res3 = $ctx->tradeService->recordTrade(new TradeInput($userId, 'FIFO', 'NYSE', 'FIFO Corp', 'USD', 'SELL', 120, 15.0, 1.0, $date3));
+    assert_true($res3->success, 'Sell failed');
+
+    $stock = $ctx->stocks->findOneBySymbol('FIFO');
+    assert_true($stock !== null, 'Stock not stored');
+
+    $realized = $ctx->trades->sumRealizedForStock($userId, (int) $stock['id']);
+    assert_float(557.6, $realized, 0.01, 'Realized P/L mismatch');
+
+    $position = $ctx->trades->findPosition($userId, (int) $stock['id']);
+    assert_true($position !== null, 'Position missing');
+    assert_float(30.0, (float) $position['qty'], 0.0001, 'Remaining quantity incorrect');
+    assert_float(12.02, (float) $position['avg_cost_ccy'], 0.001, 'Average cost after sells incorrect');
+});
+
+test('Average cost recalculates after deleting trade', function (): void {
+    $ctx = create_context();
+    $userId = 1;
+    $d1 = new DateTimeImmutable('2023-03-01');
+    $d2 = new DateTimeImmutable('2023-03-15');
+
+    $buy1 = $ctx->tradeService->recordTrade(new TradeInput($userId, 'AVGX', 'NASDAQ', 'Average Inc', 'USD', 'BUY', 10, 100.0, 0.0, $d1));
+    assert_true($buy1->success);
+    $buy2 = $ctx->tradeService->recordTrade(new TradeInput($userId, 'AVGX', 'NASDAQ', 'Average Inc', 'USD', 'BUY', 10, 120.0, 0.0, $d2));
+    assert_true($buy2->success);
+
+    $stock = $ctx->stocks->findOneBySymbol('AVGX');
+    $position = $ctx->trades->findPosition($userId, (int) $stock['id']);
+    assert_float(110.0, (float) $position['avg_cost_ccy'], 0.0001);
+
+    $ctx->tradeService->deleteTrade($userId, (int) $buy2->tradeId);
+
+    $positionAfter = $ctx->trades->findPosition($userId, (int) $stock['id']);
+    assert_float(10.0, (float) $positionAfter['qty'], 0.0001);
+    assert_float(100.0, (float) $positionAfter['avg_cost_ccy'], 0.0001);
+});
+
+test('Portfolio snapshot converts currencies using FX rates', function (): void {
+    $ctx = create_context();
+    $userId = 1;
+    $buyDate = new DateTimeImmutable('2023-05-20');
+    $quoteDate = new DateTimeImmutable('2023-06-01 15:30:00');
+
+    _fx_store($ctx->pdo, $buyDate->format('Y-m-d'), 'USD', 1.10);
+    _fx_store($ctx->pdo, $quoteDate->format('Y-m-d'), 'USD', 1.20);
+
+    $buy = $ctx->tradeService->recordTrade(new TradeInput($userId, 'ACM', 'PAR', 'Acme SA', 'EUR', 'BUY', 5, 100.0, 2.0, $buyDate));
+    assert_true($buy->success);
+
+    $ctx->adapter->quotes['ACM'] = new LiveQuote('ACM', 110.0, 108.0, 111.0, 107.0, 1000000.0, $quoteDate, false);
+
+    $snapshot = $ctx->portfolio->buildSnapshot($userId, '6M');
+    assert_equals('USD', $snapshot->baseCurrency);
+    assert_float(660.0, $snapshot->totalMarketValue, 0.01, 'Market value in base currency incorrect');
+    assert_float(602.4, $snapshot->totalCost, 0.01, 'Total cost base incorrect: got ' . $snapshot->totalCost);
+    assert_float(57.6, $snapshot->unrealized, 0.01, 'Unrealized P/L incorrect');
+    assert_float(-552.2, $snapshot->cashImpact, 0.1, 'Cash impact incorrect');
+    assert_float(12.0, $snapshot->dailyPL, 0.01, 'Daily P/L base incorrect');
+    assert_equals(1, count($snapshot->holdings));
+});
+
+test('Signals service derives momentum and RSI insights', function (): void {
+    $ctx = create_context();
+    $userId = 1;
+    $stockId = $ctx->stocks->create('MOMO', 'NYSE', 'Momentum Corp', 'USD');
+    $today = new DateTimeImmutable('now');
+    $start = $today->sub(new DateInterval('P59D'));
+
+    $date = $start;
+    $price = 50.0;
+    while ($date <= $today) {
+        $ctx->prices->insertDailyPrice($stockId, $date, [
+            'open' => $price,
+            'high' => $price + 1,
+            'low' => $price - 1,
+            'close' => $price,
+            'volume' => 10000,
+            'provider' => 'test',
+        ]);
+        $date = $date->add(new DateInterval('P1D'));
+        $price += 0.5;
+    }
+
+    $ctx->pdo->prepare('INSERT INTO user_settings_stocks(user_id, target_allocations) VALUES(?, ?)')
+        ->execute([$userId, json_encode(['MOMO' => 25.0], JSON_THROW_ON_ERROR)]);
+
+    $holding = new Holding(
+        $stockId,
+        'MOMO',
+        'NYSE',
+        'Momentum Corp',
+        'USD',
+        15.0,
+        55.0,
+        55.0,
+        'USD',
+        $price - 0.5,
+        $price - 0.5,
+        15.0 * ($price - 0.5),
+        15.0 * ($price - 0.5),
+        150.0,
+        20.0,
+        7.5,
+        7.5,
+        10.0,
+        'Tech',
+        null,
+        null,
+        false
+    );
+
+    $insights = $ctx->signals->positionInsights($userId, $holding);
+    $titles = array_map(static fn($insight) => $insight->title, $insights);
+    $joined = implode(', ', $titles);
+    assert_true(in_array('Momentum', $titles, true), 'Momentum not found: ' . $joined);
+    assert_true(in_array('Potential add', $titles, true), 'Potential add not found: ' . $joined);
+    assert_true(in_array('Overbought', $titles, true), 'Overbought not found: ' . $joined);
+    assert_true(in_array('Consider stop update', $titles, true), 'Consider stop update not found: ' . $joined);
+    assert_true(in_array('Position health', $titles, true), 'Position health not found: ' . $joined);
+});
+
+test('Integration: trades feed portfolio metrics', function (): void {
+    $ctx = create_context();
+    $userId = 1;
+    $now = new DateTimeImmutable('now');
+    $buyUsdDate = $now->sub(new DateInterval('P20D'));
+    $buyEurDate = $now->sub(new DateInterval('P18D'));
+    $sellUsdDate = $now->sub(new DateInterval('P5D'));
+    $quoteDate = $now;
+
+    _fx_store($ctx->pdo, $buyEurDate->format('Y-m-d'), 'USD', 1.05);
+    _fx_store($ctx->pdo, $quoteDate->format('Y-m-d'), 'USD', 1.10);
+
+    $usdBuy = $ctx->tradeService->recordTrade(new TradeInput($userId, 'USX', 'NYSE', 'US Stock', 'USD', 'BUY', 10, 50.0, 1.0, $buyUsdDate));
+    assert_true($usdBuy->success);
+    $eurBuy = $ctx->tradeService->recordTrade(new TradeInput($userId, 'ERX', 'FRA', 'Euro Stock', 'EUR', 'BUY', 5, 40.0, 0.5, $buyEurDate));
+    assert_true($eurBuy->success);
+    $usdSell = $ctx->tradeService->recordTrade(new TradeInput($userId, 'USX', 'NYSE', 'US Stock', 'USD', 'SELL', 4, 60.0, 1.0, $sellUsdDate));
+    assert_true($usdSell->success);
+
+    $ctx->adapter->quotes['USX'] = new LiveQuote('USX', 55.0, 54.0, 56.0, 53.5, 2000000.0, $quoteDate, false);
+    $ctx->adapter->quotes['ERX'] = new LiveQuote('ERX', 42.0, 41.0, 43.0, 40.5, 500000.0, $quoteDate, false);
+
+    $snapshot = $ctx->portfolio->buildSnapshot($userId, '6M');
+    assert_equals(2, count($snapshot->holdings));
+    $realized = $ctx->trades->sumRealized($userId);
+    assert_float(38.6, $realized, 0.01, 'Realized P/L after sell incorrect');
+    $symbols = array_map(static fn($h) => $h->symbol, $snapshot->holdings);
+    sort($symbols);
+    assert_equals(['ERX', 'USX'], $symbols);
+});
+
+$failures = 0;
+foreach ($tests as [$name, $fn]) {
+    try {
+        $fn();
+        echo ". $name\n";
+    } catch (Throwable $e) {
+        $failures++;
+        echo "F $name: " . $e->getMessage() . "\n";
+    }
+}
+
+echo $failures === 0 ? "All tests passed\n" : sprintf("%d test(s) failed\n", $failures);
+exit($failures === 0 ? 0 : 1);

--- a/views/stocks/index.php
+++ b/views/stocks/index.php
@@ -1,78 +1,455 @@
-<section class="grid md:grid-cols-3 gap-4">
-  <div class="card">
-    <h2 class="font-medium">Portfolio (cost basis)</h2>
-    <p class="text-2xl mt-2 font-semibold"><?= moneyfmt($portfolio_value) ?></p>
-    <p class="text-xs text-gray-500">Sum of qty × avg buy price for open positions.</p>
-  </div>
-  <div class="card md:col-span-2">
-    <h3 class="font-semibold mb-3">Trade — Buy</h3>
-    <form class="grid sm:grid-cols-6 gap-2" method="post" action="/stocks/buy">
-      <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
-      <input name="symbol" class="input sm:col-span-1" placeholder="AAPL" required>
-      <input name="quantity" type="number" step="0.000001" class="input sm:col-span-1" placeholder="Qty" required>
-      <input name="price" type="number" step="0.0001" class="input sm:col-span-1" placeholder="Price" required>
-      <input name="currency" class="input sm:col-span-1" value="USD">
-      <input name="trade_on" type="date" value="<?= date('Y-m-d') ?>" class="input sm:col-span-1">
-      <button class="btn btn-primary sm:col-span-1"><?= __('Buy') ?></button>
-    </form>
+<?php
+/** @var MyMoneyMap\Stocks\DTO\PortfolioSnapshot $snapshot */
+/** @var array<int, array<string, mixed>> $trades */
+/** @var string $realizedRange */
+/** @var string $chartRange */
+/** @var array{labels: list<string>, values: list<float>} $portfolioChart */
+/** @var array<string, mixed> $filters */
+/** @var array<string, mixed> $settings */
+$base = $snapshot->baseCurrency;
+$rangeOptions = ['1W' => '1W', '1M' => '1M', '3M' => '3M', '6M' => '6M', '1Y' => '1Y', 'YTD' => 'YTD'];
+$liveSymbols = [];
+foreach ($snapshot->holdings as $holdingSymbol) {
+    $liveSymbols[] = $holdingSymbol->symbol;
+}
+foreach ($snapshot->watchlist as $watch) {
+    $liveSymbols[] = $watch->symbol;
+}
+$liveSymbols = array_values(array_unique($liveSymbols));
+?>
 
-    <h3 class="font-semibold mt-6 mb-3">Trade — Sell</h3>
-    <form class="grid sm:grid-cols-6 gap-2" method="post" action="/stocks/sell">
-      <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
-      <input name="symbol" class="input sm:col-span-1" placeholder="AAPL" required>
-      <input name="quantity" type="number" step="0.000001" class="input sm:col-span-1" placeholder="Qty" required>
-      <input name="price" type="number" step="0.0001" class="input sm:col-span-1" placeholder="Price" required>
-      <input name="currency" class="input sm:col-span-1" value="USD">
-      <input name="trade_on" type="date" value="<?= date('Y-m-d') ?>" class="input sm:col-span-1">
-      <button class="btn btn-danger sm:col-span-1"><?= __('Sell') ?></button>
-    </form>
-  </div>
-</section>
+<section class="space-y-8">
+  <header class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+    <div>
+      <h1 class="text-3xl font-semibold text-slate-900 dark:text-slate-100">Stocks &amp; ETFs</h1>
+      <p class="text-sm text-slate-500 dark:text-slate-400">Live snapshot of your equity positions converted to <?= htmlspecialchars($base) ?>.</p>
+    </div>
+    <div class="flex flex-wrap gap-2">
+      <form method="get" class="flex items-center gap-2 text-sm">
+        <label class="font-medium text-slate-600 dark:text-slate-300" for="realized-range">Realized P/L</label>
+        <select id="realized-range" name="realized" class="input w-32">
+          <?php foreach ($rangeOptions as $key => $label): ?>
+            <option value="<?= $key ?>" <?= $realizedRange === $key ? 'selected' : '' ?>><?= $label ?></option>
+          <?php endforeach; ?>
+        </select>
+        <button class="btn btn-secondary">Apply</button>
+      </form>
+      <button data-open-trade class="btn btn-primary">New trade</button>
+    </div>
+  </header>
 
-<section class="mt-6 grid md:grid-cols-2 gap-6">
-  <div class="card overflow-x-auto">
-    <h3 class="font-semibold mb-3">Open Positions</h3>
-    <table class="table-glass min-w-full text-sm">
-      <thead><tr class="text-left border-b"><th class="py-2 pr-3">Symbol</th><th class="py-2 pr-3">Qty</th><th class="py-2 pr-3">Avg Buy</th><th class="py-2 pr-3">Cost</th></tr></thead>
-      <tbody>
-        <?php foreach($positions as $p): if((float)$p['qty']<=0) continue; $cost=(float)$p['qty']*(float)$p['avg_buy_price']; ?>
-          <tr class="border-b">
-            <td class="py-2 pr-3 font-medium"><?= htmlspecialchars($p['symbol']) ?></td>
-            <td class="py-2 pr-3"><?= (float)$p['qty'] ?></td>
-            <td class="py-2 pr-3"><?= moneyfmt($p['avg_buy_price']) ?></td>
-            <td class="py-2 pr-3 font-medium"><?= moneyfmt($cost) ?></td>
-          </tr>
+  <?php if (!empty($_SESSION['flash'])): ?>
+    <div class="rounded-2xl border border-rose-200/70 bg-rose-50/80 px-4 py-3 text-sm text-rose-700 shadow-sm dark:border-rose-500/40 dark:bg-rose-500/15 dark:text-rose-100">
+      <?= htmlspecialchars($_SESSION['flash']); unset($_SESSION['flash']); ?>
+    </div>
+  <?php endif; ?>
+  <?php if (!empty($_SESSION['flash_success'])): ?>
+    <div class="rounded-2xl border border-emerald-200/60 bg-emerald-50/80 px-4 py-3 text-sm text-emerald-700 shadow-sm dark:border-emerald-500/40 dark:bg-emerald-500/15 dark:text-emerald-100">
+      <?= htmlspecialchars($_SESSION['flash_success']); unset($_SESSION['flash_success']); ?>
+    </div>
+  <?php endif; ?>
+
+  <section class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+    <article class="card bg-white/70 p-5 shadow-glass dark:bg-slate-900/60">
+      <h2 class="text-sm font-medium text-slate-500 dark:text-slate-400">Total Market Value</h2>
+      <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-slate-100"><?= moneyfmt($snapshot->totalMarketValue, $base) ?></p>
+      <p class="text-xs text-slate-400">Converted to <?= htmlspecialchars($base) ?> using latest spot.</p>
+    </article>
+    <article class="card bg-white/70 p-5 shadow-glass dark:bg-slate-900/60">
+      <h2 class="text-sm font-medium text-slate-500 dark:text-slate-400">Total Cost</h2>
+      <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-slate-100"><?= moneyfmt($snapshot->totalCost, $base) ?></p>
+      <p class="text-xs text-slate-400">Average cost per instrument currency converted on spot.</p>
+    </article>
+    <article class="card bg-white/70 p-5 shadow-glass dark:bg-slate-900/60">
+      <h2 class="text-sm font-medium text-slate-500 dark:text-slate-400">Unrealized P/L</h2>
+      <p class="mt-2 text-2xl font-semibold <?= $snapshot->unrealized >= 0 ? 'text-emerald-600 dark:text-emerald-300' : 'text-rose-600 dark:text-rose-300' ?>">
+        <?= moneyfmt($snapshot->unrealized, $base) ?>
+        <span class="ml-2 text-sm font-medium text-slate-500 dark:text-slate-400"><?= number_format($snapshot->unrealizedPercent, 2) ?>%</span>
+      </p>
+      <p class="text-xs text-slate-400">Based on average cost method.</p>
+    </article>
+    <article class="card bg-white/70 p-5 shadow-glass dark:bg-slate-900/60">
+      <h2 class="text-sm font-medium text-slate-500 dark:text-slate-400">Realized P/L (<?= htmlspecialchars($realizedRange) ?>)</h2>
+      <p class="mt-2 text-2xl font-semibold <?= $snapshot->realizedPeriod >= 0 ? 'text-emerald-600 dark:text-emerald-300' : 'text-rose-600 dark:text-rose-300' ?>">
+        <?= moneyfmt($snapshot->realizedPeriod, $base) ?>
+      </p>
+      <p class="text-xs text-slate-400">FIFO cost basis for sells within period.</p>
+    </article>
+    <article class="card bg-white/70 p-5 shadow-glass dark:bg-slate-900/60">
+      <h2 class="text-sm font-medium text-slate-500 dark:text-slate-400">Cash Impact</h2>
+      <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-slate-100"><?= moneyfmt($snapshot->cashImpact, $base) ?></p>
+      <p class="text-xs text-slate-400">Net cash flows from trades (fees included).</p>
+    </article>
+    <article class="card bg-white/70 p-5 shadow-glass dark:bg-slate-900/60">
+      <h2 class="text-sm font-medium text-slate-500 dark:text-slate-400">Daily P/L</h2>
+      <p class="mt-2 text-2xl font-semibold <?= $snapshot->dailyPL >= 0 ? 'text-emerald-600 dark:text-emerald-300' : 'text-rose-600 dark:text-rose-300' ?>">
+        <?= moneyfmt($snapshot->dailyPL, $base) ?>
+      </p>
+      <p class="text-xs text-slate-400">Change since previous close.</p>
+    </article>
+  </section>
+
+  <?php if ($snapshot->insights): ?>
+    <section class="grid gap-3 rounded-3xl border border-emerald-200/50 bg-emerald-50/60 p-4 shadow-sm dark:border-emerald-500/40 dark:bg-emerald-900/20">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-200">Insights</h2>
+      <ul class="grid gap-2 md:grid-cols-2">
+        <?php foreach ($snapshot->insights as $insight): ?>
+          <li class="rounded-2xl bg-white/70 p-3 text-sm shadow-sm dark:bg-emerald-950/40">
+            <p class="font-medium text-slate-700 dark:text-emerald-100"><?= htmlspecialchars($insight->title) ?></p>
+            <p class="text-slate-500 dark:text-emerald-200/80"><?= htmlspecialchars($insight->description) ?></p>
+          </li>
         <?php endforeach; ?>
-      </tbody>
-    </table>
-  </div>
+      </ul>
+    </section>
+  <?php endif; ?>
 
-  <div class="card overflow-x-auto">
-    <h3 class="font-semibold mb-3">Recent Trades</h3>
-    <table class="table-glass min-w-full text-sm">
-      <thead><tr class="text-left border-b"><th class="py-2 pr-3">Date</th><th class="py-2 pr-3">Side</th><th class="py-2 pr-3">Symbol</th><th class="py-2 pr-3">Qty</th><th class="py-2 pr-3">Price</th><th class="py-2 pr-3">Currency</th><th class="py-2 pr-3">Actions</th></tr></thead>
-      <tbody>
-        <?php foreach($trades as $t): ?>
-          <tr class="border-b">
-            <td class="py-2 pr-3"><?= htmlspecialchars($t['trade_on']) ?></td>
-            <td class="py-2 pr-3 capitalize"><?= htmlspecialchars($t['side']) ?></td>
-            <td class="py-2 pr-3 font-medium"><?= htmlspecialchars($t['symbol']) ?></td>
-            <td class="py-2 pr-3"><?= (float)$t['quantity'] ?></td>
-            <td class="py-2 pr-3"><?= moneyfmt($t['price']) ?></td>
-            <td class="py-2 pr-3"><?= htmlspecialchars($t['currency']) ?></td>
-            <td class="py-2 pr-3">
-              <form method="post" action="/stocks/trade/delete" onsubmit="return confirm('Delete trade?')">
-                <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
-                <input type="hidden" name="id" value="<?= $t['id'] ?>" />
-                <button class="icon-action icon-action--danger" title="<?= __('Remove') ?>">
-                  <i data-lucide="trash-2" class="h-4 w-4"></i>
-                  <span class="sr-only"><?= __('Remove') ?></span>
+  <section class="grid gap-6 lg:grid-cols-2">
+    <div class="card relative overflow-hidden bg-white/80 p-4 shadow-glass dark:bg-slate-900/60">
+      <div class="flex items-center justify-between">
+        <h3 class="text-sm font-semibold text-slate-600 dark:text-slate-300">Portfolio value</h3>
+        <form method="get" class="flex items-center gap-2 text-xs">
+          <input type="hidden" name="realized" value="<?= htmlspecialchars($realizedRange) ?>">
+          <input type="hidden" name="search" value="<?= htmlspecialchars((string) ($filters['search'] ?? '')) ?>">
+          <input type="hidden" name="currency" value="<?= htmlspecialchars((string) ($filters['currency'] ?? '')) ?>">
+          <input type="hidden" name="sector" value="<?= htmlspecialchars((string) ($filters['sector'] ?? '')) ?>">
+          <label for="chart-range" class="font-medium text-slate-500 dark:text-slate-400">Range</label>
+          <select name="chart_range" id="chart-range" class="input h-8 text-xs">
+            <?php foreach (['1M','3M','6M','1Y'] as $opt): ?>
+              <option value="<?= $opt ?>" <?= $chartRange === $opt ? 'selected' : '' ?>><?= $opt ?></option>
+            <?php endforeach; ?>
+          </select>
+        </form>
+      </div>
+      <div class="mt-4 h-64">
+        <canvas id="portfolio-value-chart" class="h-full w-full"></canvas>
+      </div>
+    </div>
+
+    <div class="card bg-white/80 p-4 shadow-glass dark:bg-slate-900/60">
+      <h3 class="text-sm font-semibold text-slate-600 dark:text-slate-300">Allocation</h3>
+      <div class="mt-4 grid gap-6 sm:grid-cols-2">
+        <div class="h-56">
+          <canvas id="allocation-ticker"></canvas>
+        </div>
+        <div class="h-56">
+          <canvas id="allocation-sector"></canvas>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="card bg-white/80 p-5 shadow-glass dark:bg-slate-900/60">
+    <header class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+      <div>
+        <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Holdings</h2>
+        <p class="text-xs text-slate-500 dark:text-slate-400">Filter and search across your open positions.</p>
+      </div>
+      <form method="get" class="flex flex-wrap gap-2 text-sm">
+        <input class="input" name="search" placeholder="Symbol or name" value="<?= htmlspecialchars((string) ($filters['search'] ?? '')) ?>">
+        <input type="hidden" name="realized" value="<?= htmlspecialchars($realizedRange) ?>">
+        <select class="input" name="currency">
+          <option value="">Currency</option>
+          <?php foreach (['USD','EUR','GBP','HUF','JPY'] as $ccy): ?>
+            <option value="<?= $ccy ?>" <?= ($filters['currency'] ?? '') === $ccy ? 'selected' : '' ?>><?= $ccy ?></option>
+          <?php endforeach; ?>
+        </select>
+        <input class="input" name="sector" placeholder="Sector" value="<?= htmlspecialchars((string) ($filters['sector'] ?? '')) ?>">
+        <label class="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+          <input type="checkbox" name="watchlist" value="1" <?= !empty($filters['watchlist']) ? 'checked' : '' ?>> Watchlist only
+        </label>
+        <button class="btn btn-secondary">Filter</button>
+      </form>
+    </header>
+
+    <div class="mt-4 overflow-x-auto">
+      <table class="min-w-full text-sm">
+        <thead>
+          <tr class="text-left text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <th class="py-2 pr-3">Ticker</th>
+            <th class="py-2 pr-3">Qty</th>
+            <th class="py-2 pr-3">Avg cost</th>
+            <th class="py-2 pr-3">Last price</th>
+            <th class="py-2 pr-3">Market value</th>
+            <th class="py-2 pr-3">Unrealized</th>
+            <th class="py-2 pr-3">Day P/L</th>
+            <th class="py-2 pr-3">Weight</th>
+            <th class="py-2 pr-3">Notes</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100 dark:divide-slate-800/50">
+          <?php foreach ($snapshot->holdings as $holding): ?>
+            <tr class="hover:bg-white/60 dark:hover:bg-slate-800/40">
+              <td class="py-3 pr-3 font-semibold">
+                <a class="text-brand-600 hover:underline" href="/stocks/<?= urlencode($holding->symbol) ?>"><?= htmlspecialchars($holding->symbol) ?></a>
+                <div class="text-xs text-slate-400"><?= htmlspecialchars($holding->currency) ?></div>
+              </td>
+              <td class="py-3 pr-3 text-slate-600 dark:text-slate-300"><?= number_format($holding->quantity, 4) ?></td>
+              <td class="py-3 pr-3 text-slate-600 dark:text-slate-300">
+                <?= moneyfmt($holding->averageCost, $holding->currency) ?>
+                <div class="text-xs text-slate-400"><?= moneyfmt($holding->averageCostBase, $base) ?></div>
+              </td>
+              <td class="py-3 pr-3 text-slate-600 dark:text-slate-300">
+                <span data-live-last="<?= htmlspecialchars($holding->symbol) ?>" data-currency="<?= htmlspecialchars($holding->currency) ?>"><?= moneyfmt($holding->lastPrice, $holding->currency) ?></span>
+                <div class="text-xs text-slate-400"><?= moneyfmt($holding->lastPriceBase, $base) ?></div>
+              </td>
+              <td class="py-3 pr-3 text-slate-600 dark:text-slate-300">
+                <?= moneyfmt($holding->marketValue, $holding->currency) ?>
+                <div class="text-xs text-slate-400"><?= moneyfmt($holding->marketValueBase, $base) ?></div>
+              </td>
+              <td class="py-3 pr-3 <?= $holding->unrealized >= 0 ? 'text-emerald-600 dark:text-emerald-300' : 'text-rose-600 dark:text-rose-300' ?>">
+                <?= moneyfmt($holding->unrealized, $base) ?> (<?= number_format($holding->unrealizedPercent, 2) ?>%)
+              </td>
+              <td class="py-3 pr-3 <?= $holding->dayChangeBase >= 0 ? 'text-emerald-600 dark:text-emerald-300' : 'text-rose-600 dark:text-rose-300' ?>">
+                <span data-live-change="<?= htmlspecialchars($holding->symbol) ?>" data-currency="<?= htmlspecialchars($holding->currency) ?>" data-base="<?= htmlspecialchars($base) ?>"><?= moneyfmt($holding->dayChange, $holding->currency) ?></span>
+                <div class="text-xs text-slate-400"><?= moneyfmt($holding->dayChangeBase, $base) ?></div>
+              </td>
+              <td class="py-3 pr-3 text-slate-600 dark:text-slate-300"><?= number_format($holding->weight, 2) ?>%</td>
+              <td class="py-3 pr-3 text-xs text-slate-500 dark:text-slate-400">
+                <?php if ($holding->concentrationWarning): ?>
+                  <span class="inline-flex items-center gap-1 rounded-full bg-rose-100 px-2 py-1 text-xs font-medium text-rose-700 dark:bg-rose-500/20 dark:text-rose-200">
+                    <i data-lucide="alert-triangle" class="h-3 w-3"></i> Concentrated
+                  </span>
+                <?php else: ?>
+                  <span class="text-slate-400">—</span>
+                <?php endif; ?>
+              </td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <?php if ($snapshot->watchlist): ?>
+    <section class="card bg-white/80 p-4 shadow-glass dark:bg-slate-900/60">
+      <header class="flex items-center justify-between">
+        <h3 class="text-sm font-semibold text-slate-600 dark:text-slate-300">Watchlist</h3>
+      </header>
+      <div class="mt-4 flex flex-wrap gap-4">
+        <?php foreach ($snapshot->watchlist as $entry): ?>
+          <div class="min-w-[180px] rounded-2xl border border-slate-200/60 bg-white/70 px-4 py-3 shadow-sm dark:border-slate-800/60 dark:bg-slate-900/50">
+            <div class="flex items-center justify-between">
+              <a href="/stocks/<?= urlencode($entry->symbol) ?>" class="font-semibold text-slate-800 hover:text-brand-600 dark:text-slate-100"><?= htmlspecialchars($entry->symbol) ?></a>
+              <form method="post" action="/stocks/watch">
+                <input type="hidden" name="csrf" value="<?= csrf_token() ?>">
+                <input type="hidden" name="stock_id" value="<?= $entry->stockId ?>">
+                <button class="icon-action" title="Toggle watch">
+                  <i data-lucide="star" class="h-4 w-4 text-amber-400"></i>
                 </button>
               </form>
-            </td>
-          </tr>
+            </div>
+            <div class="text-xs text-slate-400"><?= htmlspecialchars($entry->currency) ?></div>
+            <?php if ($entry->quote): ?>
+              <p class="mt-2 text-lg font-semibold text-slate-800 dark:text-slate-100"><span data-live-last="<?= htmlspecialchars($entry->symbol) ?>" data-currency="<?= htmlspecialchars($entry->currency) ?>"><?= moneyfmt($entry->quote->last, $entry->currency) ?></span></p>
+              <p class="text-xs <?= $entry->quote->change() >= 0 ? 'text-emerald-600' : 'text-rose-600' ?>"><span data-live-change="<?= htmlspecialchars($entry->symbol) ?>" data-currency="<?= htmlspecialchars($entry->currency) ?>" data-base="<?= htmlspecialchars($base) ?>"><?= moneyfmt($entry->quote->change(), $entry->currency) ?></span> (<?= number_format($entry->quote->percentChange(), 2) ?>%)
+              </p>
+            <?php else: ?>
+              <p class="mt-2 text-xs text-slate-400">No live quote</p>
+            <?php endif; ?>
+            <a href="/stocks/<?= urlencode($entry->symbol) ?>" class="mt-2 inline-flex items-center gap-1 text-xs text-brand-600 hover:underline">Trade</a>
+          </div>
         <?php endforeach; ?>
-      </tbody>
-    </table>
-  </div>
+      </div>
+    </section>
+  <?php endif; ?>
+
+  <section class="card bg-white/80 p-5 shadow-glass dark:bg-slate-900/60">
+    <h3 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Recent trades</h3>
+    <div class="mt-4 overflow-x-auto">
+      <table class="min-w-full text-sm">
+        <thead>
+          <tr class="text-left text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <th class="py-2 pr-3">Date</th>
+            <th class="py-2 pr-3">Side</th>
+            <th class="py-2 pr-3">Symbol</th>
+            <th class="py-2 pr-3">Qty</th>
+            <th class="py-2 pr-3">Price</th>
+            <th class="py-2 pr-3">Fee</th>
+            <th class="py-2 pr-3">Currency</th>
+            <th class="py-2 pr-3">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100 dark:divide-slate-800/50">
+          <?php foreach ($trades as $trade): ?>
+            <tr>
+              <td class="py-2 pr-3 text-slate-600 dark:text-slate-300"><?= htmlspecialchars(date('Y-m-d H:i', strtotime($trade['executed_at']))) ?></td>
+              <td class="py-2 pr-3 capitalize text-slate-600 dark:text-slate-300"><?= htmlspecialchars(strtolower($trade['side'])) ?></td>
+              <td class="py-2 pr-3 font-semibold"><a class="text-brand-600 hover:underline" href="/stocks/<?= urlencode($trade['symbol']) ?>"><?= htmlspecialchars($trade['symbol']) ?></a></td>
+              <td class="py-2 pr-3 text-slate-600 dark:text-slate-300"><?= number_format((float)$trade['qty'], 4) ?></td>
+              <td class="py-2 pr-3 text-slate-600 dark:text-slate-300"><?= moneyfmt($trade['price'], $trade['currency']) ?></td>
+              <td class="py-2 pr-3 text-slate-600 dark:text-slate-300"><?= moneyfmt($trade['fee'], $trade['currency']) ?></td>
+              <td class="py-2 pr-3 text-slate-500 dark:text-slate-400"><?= htmlspecialchars($trade['currency']) ?></td>
+              <td class="py-2 pr-3">
+                <form method="post" action="/stocks/trade/delete" onsubmit="return confirm('Delete trade?')">
+                  <input type="hidden" name="csrf" value="<?= csrf_token() ?>">
+                  <input type="hidden" name="id" value="<?= (int)$trade['id'] ?>">
+                  <button class="icon-action icon-action--danger" title="Remove">
+                    <i data-lucide="trash-2" class="h-4 w-4"></i>
+                  </button>
+                </form>
+              </td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+  </section>
 </section>
+
+<div id="trade-drawer" class="fixed inset-0 z-40 hidden bg-slate-900/40 backdrop-blur-sm">
+  <div class="absolute right-0 top-0 h-full w-full max-w-md overflow-y-auto bg-white p-6 shadow-2xl dark:bg-slate-900">
+    <header class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Record trade</h2>
+      <button data-close-trade class="icon-action"><i data-lucide="x" class="h-5 w-5"></i></button>
+    </header>
+    <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Supports buy or sell tickets with fees and notes.</p>
+
+    <form class="mt-6 space-y-4" method="post" action="/stocks/buy" data-trade-form>
+      <input type="hidden" name="csrf" value="<?= csrf_token() ?>">
+      <input type="hidden" name="side" value="BUY">
+      <div class="grid grid-cols-2 gap-3">
+        <label class="text-xs font-medium text-slate-500">Symbol
+          <input name="symbol" class="input mt-1" placeholder="AAPL" required>
+        </label>
+        <label class="text-xs font-medium text-slate-500">Exchange
+          <input name="exchange" class="input mt-1" placeholder="NASDAQ">
+        </label>
+      </div>
+      <label class="text-xs font-medium text-slate-500">Company name
+        <input name="name" class="input mt-1" placeholder="Apple Inc.">
+      </label>
+      <div class="grid grid-cols-2 gap-3">
+        <label class="text-xs font-medium text-slate-500">Quantity
+          <input name="quantity" type="number" step="0.0001" class="input mt-1" required>
+        </label>
+        <label class="text-xs font-medium text-slate-500">Price
+          <input name="price" type="number" step="0.0001" class="input mt-1" required>
+        </label>
+      </div>
+      <div class="grid grid-cols-2 gap-3">
+        <label class="text-xs font-medium text-slate-500">Currency
+          <input name="currency" class="input mt-1" value="USD">
+        </label>
+        <label class="text-xs font-medium text-slate-500">Fee
+          <input name="fee" type="number" step="0.01" class="input mt-1" value="0">
+        </label>
+      </div>
+      <label class="text-xs font-medium text-slate-500">Executed at
+        <input name="executed_at" type="datetime-local" class="input mt-1" value="<?= date('Y-m-d\TH:i') ?>">
+      </label>
+      <label class="text-xs font-medium text-slate-500">Note
+        <textarea name="note" class="input mt-1" rows="2"></textarea>
+      </label>
+      <div class="flex items-center gap-2">
+        <button class="btn btn-primary">Save trade</button>
+        <button type="button" data-close-trade class="btn btn-secondary">Cancel</button>
+      </div>
+    </form>
+
+    <hr class="my-6 border-slate-200 dark:border-slate-800">
+
+    <form class="space-y-4" method="post" action="/stocks/sell" data-trade-form>
+      <input type="hidden" name="csrf" value="<?= csrf_token() ?>">
+      <input type="hidden" name="side" value="SELL">
+      <div class="grid grid-cols-2 gap-3">
+        <label class="text-xs font-medium text-slate-500">Symbol
+          <input name="symbol" class="input mt-1" placeholder="AAPL" required>
+        </label>
+        <label class="text-xs font-medium text-slate-500">Exchange
+          <input name="exchange" class="input mt-1" placeholder="NASDAQ">
+        </label>
+      </div>
+      <div class="grid grid-cols-2 gap-3">
+        <label class="text-xs font-medium text-slate-500">Quantity
+          <input name="quantity" type="number" step="0.0001" class="input mt-1" required>
+        </label>
+        <label class="text-xs font-medium text-slate-500">Price
+          <input name="price" type="number" step="0.0001" class="input mt-1" required>
+        </label>
+      </div>
+      <div class="grid grid-cols-2 gap-3">
+        <label class="text-xs font-medium text-slate-500">Currency
+          <input name="currency" class="input mt-1" value="USD">
+        </label>
+        <label class="text-xs font-medium text-slate-500">Fee
+          <input name="fee" type="number" step="0.01" class="input mt-1" value="0">
+        </label>
+      </div>
+      <label class="text-xs font-medium text-slate-500">Executed at
+        <input name="executed_at" type="datetime-local" class="input mt-1" value="<?= date('Y-m-d\TH:i') ?>">
+      </label>
+      <label class="text-xs font-medium text-slate-500">Note
+        <textarea name="note" class="input mt-1" rows="2"></textarea>
+      </label>
+      <div class="flex items-center gap-2">
+        <button class="btn btn-danger">Record sell</button>
+        <div class="flex items-center gap-2 text-xs text-slate-500">
+          <button type="button" data-qty="1" class="chip">+1</button>
+          <button type="button" data-qty="10" class="chip">+10</button>
+          <button type="button" data-qty="100" class="chip">+100</button>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script>
+  (function () {
+    const chartData = <?= json_encode($portfolioChart, JSON_UNESCAPED_SLASHES) ?>;
+    window.renderLineChart && window.renderLineChart('portfolio-value-chart', chartData.labels, chartData.values);
+
+    const allocTicker = <?= json_encode(array_map(fn($slice) => ['label' => $slice->label, 'value' => $slice->value], $snapshot->allocationsByTicker), JSON_UNESCAPED_SLASHES) ?>;
+    const allocSector = <?= json_encode(array_map(fn($slice) => ['label' => $slice->label, 'value' => $slice->value], $snapshot->allocationsBySector), JSON_UNESCAPED_SLASHES) ?>;
+    window.renderDoughnut && window.renderDoughnut('allocation-ticker', allocTicker.map(x => x.label), allocTicker.map(x => x.value));
+    window.renderDoughnut && window.renderDoughnut('allocation-sector', allocSector.map(x => x.label), allocSector.map(x => x.value));
+
+    const drawer = document.getElementById('trade-drawer');
+    const openButtons = document.querySelectorAll('[data-open-trade]');
+    const closeButtons = document.querySelectorAll('[data-close-trade]');
+    openButtons.forEach(btn => btn.addEventListener('click', () => drawer?.classList.remove('hidden')));
+    closeButtons.forEach(btn => btn.addEventListener('click', () => drawer?.classList.add('hidden')));
+
+    document.querySelectorAll('form[data-trade-form] button.chip').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const qtyInput = btn.closest('form')?.querySelector('input[name="quantity"]');
+        if (!qtyInput) return;
+        const base = parseFloat(qtyInput.value || '0');
+        const increment = parseFloat(btn.dataset.qty || '0');
+        qtyInput.value = (base + increment).toFixed(4);
+      });
+    });
+
+    const liveSymbols = <?= json_encode($liveSymbols, JSON_UNESCAPED_SLASHES) ?>;
+    if (liveSymbols.length) {
+      const formatCurrency = (value, currency, sign = false) => {
+        try {
+          return new Intl.NumberFormat(undefined, { style: 'currency', currency, signDisplay: sign ? 'exceptZero' : 'auto' }).format(value);
+        } catch (err) {
+          return (sign && value > 0 ? '+' : '') + value.toFixed(2) + ' ' + currency;
+        }
+      };
+      const fetchQuotes = () => {
+        if (document.hidden) return;
+        fetch('/api/stocks/live?symbols=' + liveSymbols.join(','))
+          .then(resp => resp.json())
+          .then(payload => {
+            (payload.quotes || []).forEach(item => {
+              const symbol = item.symbol;
+              document.querySelectorAll('[data-live-last= + symbol + ]').forEach(el => {
+                const currency = el.dataset.currency || 'USD';
+                el.textContent = formatCurrency(item.last, currency, false);
+              });
+              document.querySelectorAll('[data-live-change= + symbol + ]').forEach(el => {
+                const currency = el.dataset.currency || 'USD';
+                el.textContent = formatCurrency(item.last - item.prev_close, currency, true);
+              });
+            });
+          })
+          .catch(() => {});
+      };
+      fetchQuotes();
+      setInterval(fetchQuotes, 8000);
+      document.addEventListener('visibilitychange', () => { if (!document.hidden) fetchQuotes(); });
+    }
+  })();
+</script>

--- a/views/stocks/show.php
+++ b/views/stocks/show.php
@@ -1,0 +1,211 @@
+<?php
+/** @var array<string, mixed> $stock */
+/** @var ?MyMoneyMap\Stocks\DTO\Holding $holding */
+/** @var ?MyMoneyMap\Stocks\DTO\LiveQuote $quote */
+/** @var array{labels: list<string>, values: list<float>} $priceSeries */
+/** @var array{labels: list<string>, values: list<float>} $positionSeries */
+/** @var float $realizedYtd */
+/** @var list<MyMoneyMap\Stocks\DTO\Insight> $insights */
+/** @var array<string, mixed> $settings */
+/** @var bool $isWatched */
+$base = fx_user_main($pdo, uid());
+?>
+
+<section class="space-y-8">
+  <header class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+    <div>
+      <div class="flex items-center gap-3">
+        <h1 class="text-3xl font-semibold text-slate-900 dark:text-slate-100"><?= htmlspecialchars($stock['symbol']) ?></h1>
+        <?php if (!empty($stock['exchange'])): ?>
+          <span class="rounded-full border border-slate-200 px-2 py-1 text-xs text-slate-500 dark:border-slate-700 dark:text-slate-300"><?= htmlspecialchars($stock['exchange']) ?></span>
+        <?php endif; ?>
+      </div>
+      <p class="text-sm text-slate-500 dark:text-slate-400"><?= htmlspecialchars($stock['name'] ?? '') ?></p>
+      <div class="mt-1 flex flex-wrap gap-3 text-xs text-slate-400 dark:text-slate-500">
+        <?php if (!empty($stock['sector'])): ?><span><?= htmlspecialchars($stock['sector']) ?></span><?php endif; ?>
+        <?php if (!empty($stock['industry'])): ?><span><?= htmlspecialchars($stock['industry']) ?></span><?php endif; ?>
+        <?php if (!empty($stock['currency'])): ?><span>Currency: <?= htmlspecialchars($stock['currency']) ?></span><?php endif; ?>
+      </div>
+    </div>
+    <form method="post" action="/stocks/watch" class="flex items-center gap-2">
+      <input type="hidden" name="csrf" value="<?= csrf_token() ?>">
+      <input type="hidden" name="stock_id" value="<?= (int) $stock['id'] ?>">
+      <button class="btn <?= $isWatched ? 'btn-secondary' : 'btn-primary' ?>" type="submit">
+        <i data-lucide="star" class="mr-1 h-4 w-4"></i>
+        <?= $isWatched ? 'Unwatch' : 'Add to watchlist' ?>
+      </button>
+      <button data-open-trade class="btn btn-primary">Record trade</button>
+    </form>
+  </header>
+
+  <section class="grid gap-6 lg:grid-cols-3">
+    <article class="card bg-white/80 p-5 shadow-glass dark:bg-slate-900/60 lg:col-span-2">
+      <header class="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 class="text-sm font-medium text-slate-500 dark:text-slate-300">Live price</h2>
+          <p class="text-3xl font-semibold text-slate-900 dark:text-slate-100"><?= $quote ? moneyfmt($quote->last, $stock['currency']) : '—' ?></p>
+          <?php if ($quote): ?>
+            <p class="text-sm <?= $quote->change() >= 0 ? 'text-emerald-600 dark:text-emerald-300' : 'text-rose-600 dark:text-rose-300' ?>">
+              <?= moneyfmt($quote->change(), $stock['currency']) ?> (<?= number_format($quote->percentChange(), 2) ?>%)
+              <span class="ml-2 text-xs text-slate-400">As of <?= $quote->asOf->format('H:i') ?></span>
+            </p>
+          <?php else: ?>
+            <p class="text-xs text-slate-400">No live quote available.</p>
+          <?php endif; ?>
+        </div>
+        <dl class="grid grid-cols-2 gap-x-6 gap-y-2 text-xs text-slate-500 dark:text-slate-400">
+          <div><dt class="font-medium text-slate-600 dark:text-slate-300">Day high</dt><dd><?= $quote ? moneyfmt($quote->dayHigh, $stock['currency']) : '—' ?></dd></div>
+          <div><dt class="font-medium text-slate-600 dark:text-slate-300">Day low</dt><dd><?= $quote ? moneyfmt($quote->dayLow, $stock['currency']) : '—' ?></dd></div>
+          <div><dt class="font-medium text-slate-600 dark:text-slate-300">Prev close</dt><dd><?= $quote ? moneyfmt($quote->previousClose, $stock['currency']) : '—' ?></dd></div>
+          <div><dt class="font-medium text-slate-600 dark:text-slate-300">Volume</dt><dd><?= $quote ? number_format($quote->volume) : '—' ?></dd></div>
+        </dl>
+      </header>
+      <div class="mt-6">
+        <div class="flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
+          <?php foreach (['1M','3M','6M','1Y','5Y'] as $range): ?>
+            <button data-range="<?= $range ?>" class="chip <?= $range === '6M' ? 'bg-brand-500/20 text-brand-700 dark:bg-emerald-500/20 dark:text-emerald-100' : '' ?>"><?= $range ?></button>
+          <?php endforeach; ?>
+        </div>
+        <div class="mt-4 h-72">
+          <canvas id="price-chart"></canvas>
+        </div>
+      </div>
+    </article>
+    <article class="card bg-white/80 p-5 shadow-glass dark:bg-slate-900/60">
+      <h2 class="text-sm font-medium text-slate-500 dark:text-slate-300">Position</h2>
+      <?php if ($holding): ?>
+        <dl class="mt-3 space-y-3 text-sm text-slate-600 dark:text-slate-300">
+          <div class="flex items-center justify-between"><dt>Quantity</dt><dd><?= number_format($holding->quantity, 4) ?></dd></div>
+          <div class="flex items-center justify-between"><dt>Average cost</dt><dd><?= moneyfmt($holding->averageCost, $stock['currency']) ?> <span class="text-xs text-slate-400">(<?= moneyfmt($holding->averageCostBase, $base) ?>)</span></dd></div>
+          <div class="flex items-center justify-between"><dt>Market value</dt><dd><?= moneyfmt($holding->marketValueBase, $base) ?></dd></div>
+          <div class="flex items-center justify-between <?= $holding->unrealized >= 0 ? 'text-emerald-600 dark:text-emerald-300' : 'text-rose-600 dark:text-rose-300' ?>"><dt>Unrealized</dt><dd><?= moneyfmt($holding->unrealized, $base) ?> (<?= number_format($holding->unrealizedPercent, 2) ?>%)</dd></div>
+          <div class="flex items-center justify-between"><dt>Weight</dt><dd><?= number_format($holding->weight, 2) ?>%</dd></div>
+          <div class="flex items-center justify-between"><dt>Realized P/L (YTD)</dt><dd><?= moneyfmt($realizedYtd, $base) ?></dd></div>
+        </dl>
+      <?php else: ?>
+        <p class="mt-3 text-sm text-slate-500 dark:text-slate-400">No open position. Use the trade form to start tracking.</p>
+      <?php endif; ?>
+      <div class="mt-6">
+        <h3 class="text-xs font-semibold uppercase text-slate-500 dark:text-slate-400">Position value</h3>
+        <div class="mt-3 h-40"><canvas id="position-chart"></canvas></div>
+      </div>
+    </article>
+  </section>
+
+  <?php if ($insights): ?>
+    <section class="card bg-white/80 p-4 shadow-glass dark:bg-slate-900/60">
+      <h2 class="text-sm font-semibold text-slate-600 dark:text-slate-300">Insights</h2>
+      <ul class="mt-3 grid gap-3 md:grid-cols-2">
+        <?php foreach ($insights as $insight): ?>
+          <li class="rounded-2xl bg-slate-50/80 p-3 text-sm shadow-sm dark:bg-slate-800/60">
+            <p class="font-semibold text-slate-700 dark:text-slate-100"><?= htmlspecialchars($insight->title) ?></p>
+            <p class="text-slate-500 dark:text-slate-300"><?= htmlspecialchars($insight->description) ?></p>
+          </li>
+        <?php endforeach; ?>
+      </ul>
+    </section>
+  <?php endif; ?>
+</section>
+
+<div id="trade-drawer" class="fixed inset-0 z-40 hidden bg-slate-900/40 backdrop-blur-sm">
+  <div class="absolute right-0 top-0 h-full w-full max-w-md overflow-y-auto bg-white p-6 shadow-2xl dark:bg-slate-900">
+    <header class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Record trade</h2>
+      <button data-close-trade class="icon-action"><i data-lucide="x" class="h-5 w-5"></i></button>
+    </header>
+    <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">Ticket for <?= htmlspecialchars($stock['symbol']) ?>.</p>
+
+    <form class="mt-6 space-y-4" method="post" action="/stocks/buy" data-trade-form>
+      <input type="hidden" name="csrf" value="<?= csrf_token() ?>">
+      <input type="hidden" name="symbol" value="<?= htmlspecialchars($stock['symbol']) ?>">
+      <input type="hidden" name="exchange" value="<?= htmlspecialchars($stock['exchange'] ?? '') ?>">
+      <input type="hidden" name="name" value="<?= htmlspecialchars($stock['name'] ?? '') ?>">
+      <input type="hidden" name="currency" value="<?= htmlspecialchars($stock['currency'] ?? 'USD') ?>">
+      <label class="text-xs font-medium text-slate-500">Quantity
+        <input name="quantity" type="number" step="0.0001" class="input mt-1" required>
+      </label>
+      <label class="text-xs font-medium text-slate-500">Price
+        <input name="price" type="number" step="0.0001" class="input mt-1" required>
+      </label>
+      <label class="text-xs font-medium text-slate-500">Fee
+        <input name="fee" type="number" step="0.01" class="input mt-1" value="0">
+      </label>
+      <label class="text-xs font-medium text-slate-500">Executed at
+        <input name="executed_at" type="datetime-local" class="input mt-1" value="<?= date('Y-m-d\TH:i') ?>">
+      </label>
+      <label class="text-xs font-medium text-slate-500">Note
+        <textarea name="note" class="input mt-1" rows="2"></textarea>
+      </label>
+      <div class="flex items-center gap-2">
+        <button class="btn btn-primary">Save buy</button>
+        <button type="button" data-close-trade class="btn btn-secondary">Cancel</button>
+      </div>
+    </form>
+
+    <hr class="my-6 border-slate-200 dark:border-slate-800">
+
+    <form class="space-y-4" method="post" action="/stocks/sell" data-trade-form>
+      <input type="hidden" name="csrf" value="<?= csrf_token() ?>">
+      <input type="hidden" name="symbol" value="<?= htmlspecialchars($stock['symbol']) ?>">
+      <input type="hidden" name="exchange" value="<?= htmlspecialchars($stock['exchange'] ?? '') ?>">
+      <input type="hidden" name="currency" value="<?= htmlspecialchars($stock['currency'] ?? 'USD') ?>">
+      <label class="text-xs font-medium text-slate-500">Quantity
+        <input name="quantity" type="number" step="0.0001" class="input mt-1" required>
+      </label>
+      <label class="text-xs font-medium text-slate-500">Price
+        <input name="price" type="number" step="0.0001" class="input mt-1" required>
+      </label>
+      <label class="text-xs font-medium text-slate-500">Fee
+        <input name="fee" type="number" step="0.01" class="input mt-1" value="0">
+      </label>
+      <label class="text-xs font-medium text-slate-500">Executed at
+        <input name="executed_at" type="datetime-local" class="input mt-1" value="<?= date('Y-m-d\TH:i') ?>">
+      </label>
+      <label class="text-xs font-medium text-slate-500">Note
+        <textarea name="note" class="input mt-1" rows="2"></textarea>
+      </label>
+      <div class="flex items-center gap-2">
+        <button class="btn btn-danger">Record sell</button>
+        <div class="flex items-center gap-2 text-xs text-slate-500">
+          <button type="button" data-qty="1" class="chip">+1</button>
+          <button type="button" data-qty="10" class="chip">+10</button>
+          <button type="button" data-qty="100" class="chip">+100</button>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script>
+  (function () {
+    const priceSeries = <?= json_encode($priceSeries, JSON_UNESCAPED_SLASHES) ?>;
+    window.renderLineChart && window.renderLineChart('price-chart', priceSeries.labels, priceSeries.values);
+    const positionSeries = <?= json_encode($positionSeries, JSON_UNESCAPED_SLASHES) ?>;
+    window.renderLineChart && window.renderLineChart('position-chart', positionSeries.labels, positionSeries.values);
+
+    const drawer = document.getElementById('trade-drawer');
+    document.querySelectorAll('[data-open-trade]').forEach(btn => btn.addEventListener('click', () => drawer?.classList.remove('hidden')));
+    document.querySelectorAll('[data-close-trade]').forEach(btn => btn.addEventListener('click', () => drawer?.classList.add('hidden')));
+    document.querySelectorAll('form[data-trade-form] button.chip').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const qty = btn.closest('form')?.querySelector('input[name="quantity"]');
+        if (!qty) return;
+        qty.value = (parseFloat(qty.value || '0') + parseFloat(btn.dataset.qty || '0')).toFixed(4);
+      });
+    });
+
+    document.querySelectorAll('[data-range]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const range = btn.dataset.range;
+        fetch(`/api/stocks/<?= urlencode($stock['symbol']) ?>/history?range=${range}`)
+          .then(resp => resp.json())
+          .then(data => {
+            if (!data.candles) return;
+            const labels = data.candles.map(item => item.date);
+            const values = data.candles.map(item => item.close);
+            window.renderLineChart && window.renderLineChart('price-chart', labels, values);
+          });
+      });
+    });
+  })();
+</script>


### PR DESCRIPTION
## Summary
- complete the stocks data services/repositories, including cash-impact rebuilds and SQLite-safe SQL
- wire controller routing fixes and FX helper driver detection for multi-database support
- add PHPUnit-style coverage for FIFO lots, FX conversion, signals, and integration scenarios

## Testing
- php tests/stocks_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68dbee6b8ec88329b776793af35e07ff