### PR TITLE
Implement comprehensive stocks tracking module

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -21,4 +21,14 @@ return [
             'es' => 'Español',
         ],
     ],
+    'stocks' => [
+        'provider' => getenv('STOCKS_PROVIDER') ?: 'null',
+        'refresh_seconds' => (int)(getenv('STOCKS_REFRESH_SECONDS') ?: 10),
+        'providers' => [
+            'finnhub' => [
+                'api_key' => getenv('FINNHUB_API_KEY') ?: '',
+                'base_url' => getenv('FINNHUB_BASE_URL') ?: 'https://finnhub.io/api/v1',
+            ],
+        ],
+    ],
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -24,6 +24,8 @@ return [
     'stocks' => [
         'provider' => getenv('STOCKS_PROVIDER') ?: 'null',
         'refresh_seconds' => (int)(getenv('STOCKS_REFRESH_SECONDS') ?: 10),
+        'overview_cache_seconds' => (int)(getenv('STOCKS_OVERVIEW_CACHE_SECONDS') ?: 20),
+        'overview_cache_dir' => getenv('STOCKS_OVERVIEW_CACHE_DIR') ?: __DIR__ . '/../storage/cache/stocks',
         'providers' => [
             'finnhub' => [
                 'api_key' => getenv('FINNHUB_API_KEY') ?: '',

--- a/config/config.php
+++ b/config/config.php
@@ -26,6 +26,7 @@ return [
         'refresh_seconds' => (int)(getenv('STOCKS_REFRESH_SECONDS') ?: 10),
         'overview_cache_seconds' => (int)(getenv('STOCKS_OVERVIEW_CACHE_SECONDS') ?: 20),
         'overview_cache_dir' => getenv('STOCKS_OVERVIEW_CACHE_DIR') ?: __DIR__ . '/../storage/cache/stocks',
+        'performance_log' => getenv('STOCKS_PERFORMANCE_LOG') ?: __DIR__ . '/../storage/logs/stocks_performance.log',
         'providers' => [
             'finnhub' => [
                 'api_key' => getenv('FINNHUB_API_KEY') ?: '',

--- a/docs/stocks.md
+++ b/docs/stocks.md
@@ -54,6 +54,14 @@ php scripts/stocks_backfill.php --symbol=AAPL --from=2023-01-01 --to=2023-12-31
 
 - On the stock detail page you can switch the price chart range (1D/5D/1M/6M/1Y/5Y). The buttons fetch `/api/stocks/{symbol}/history?range=...` via AJAX and refresh both the price line and the position value chart without a full page reload.
 
+## Bulk import via CSV
+
+- From `/stocks` you can upload a broker export to backfill historical trades.
+- The importer looks for headers named **Date**, **Ticker/Symbol**, **Type**, **Quantity**, **Price per share**, **Total Amount**, **Currency**, and **Fee** (case-insensitive; extra columns are ignored).
+- Rows whose type includes `BUY` or `SELL` become trades; cash top-ups/withdrawals, dividends, and interest rows are skipped automatically.
+- Fees are taken from the `Fee` column when present, otherwise we infer them from the difference between `Total Amount` and `Quantity × Price`.
+- After uploading, the page flashes a summary including any skipped rows so you can reconcile what was imported.
+
 ## Cost-basis preferences
 
 User preferences are stored in `user_settings_stocks`:

--- a/docs/stocks.md
+++ b/docs/stocks.md
@@ -1,0 +1,94 @@
+# Stocks module
+
+The stocks module lets you record equity trades, track positions and watchlists, and fetch live pricing through pluggable providers.
+
+## Configuration
+
+Set the following environment variables (or edit `config/config.php`):
+
+- `STOCKS_PROVIDER` – provider key (`null`, `finnhub`, ...). Defaults to `null` which disables remote quotes.
+- `STOCKS_REFRESH_SECONDS` – polling interval for live quotes (default `10`).
+- `FINNHUB_API_KEY` – required when `STOCKS_PROVIDER=finnhub`.
+- `FINNHUB_BASE_URL` – optional override for the Finnhub API base URL.
+
+Provider-specific settings are merged with the config array returned from `config/config.php` under the `stocks.providers` key.
+
+## Database
+
+Run migrations to create the new tables:
+
+```sh
+psql "$DATABASE_URL" -f migrations/011_stocks_overhaul.sql
+```
+
+The migration introduces:
+
+- `stocks` master data
+- `stock_prices_last` cache of live quotes
+- `price_daily` historical candles
+- `stock_positions`, `stock_lots`, `stock_realized_pl` for cost basis tracking
+- `watchlist` and `user_settings_stocks`
+
+Existing trade history is preserved. New trades should be recorded through the `Stocks\TradeService` which rebuilds lots and realized P/L.
+
+## Backfilling prices
+
+Use the helper CLI to backfill daily candles:
+
+```sh
+php scripts/stocks_backfill.php --symbol=AAPL --from=2023-01-01 --to=2023-12-31
+```
+
+(See `scripts/stocks_backfill.php` for usage. The script will request candles via the configured provider and upsert them into `price_daily`.)
+
+## UI notes
+
+- On the stock detail page you can switch the price chart range (1D/5D/1M/6M/1Y/5Y). The buttons fetch `/api/stocks/{symbol}/history?range=...` via AJAX and refresh both the price line and the position value chart without a full page reload.
+
+## Cost-basis preferences
+
+User preferences are stored in `user_settings_stocks`:
+
+- `unrealized_method` – currently supports `AVERAGE` (default)
+- `realized_method` – currently supports `FIFO`
+- `refresh_seconds` – overrides live quote polling interval per user
+- `target_allocations` – JSON map of target weights (percent) used by the insights engine
+
+You can seed defaults during onboarding:
+
+```sql
+INSERT INTO user_settings_stocks(user_id) VALUES (123) ON CONFLICT (user_id) DO NOTHING;
+```
+
+## Demo data
+
+After running the migration, seed a few example symbols and trades for testing:
+
+```sql
+INSERT INTO stocks(symbol, market, name, currency) VALUES
+  ('AAPL','NASDAQ','Apple Inc.','USD'),
+  ('MSFT','NASDAQ','Microsoft Corp.','USD'),
+  ('SAP','XETRA','SAP SE','EUR')
+ON CONFLICT DO NOTHING;
+
+-- Example buys
+INSERT INTO stock_trades(user_id, stock_id, symbol, trade_on, side, quantity, price, currency, executed_at, fee, created_at)
+SELECT 1, id, symbol, '2023-01-15', 'buy', 5, 135.25, currency, '2023-01-15 15:30:00', 1.5, NOW()
+FROM stocks WHERE symbol='AAPL';
+```
+
+Then run the rebuild command to populate lots and positions:
+
+```sh
+php scripts/stocks_rebuild.php --user=1
+```
+
+## Tests
+
+Execute the lightweight regression tests:
+
+```sh
+php tests/stocks/trade_service_test.php
+```
+
+The tests cover FIFO realised P/L, average-cost recomputation, FX conversion helpers and signal generation.

--- a/docs/stocks.md
+++ b/docs/stocks.md
@@ -61,6 +61,7 @@ php scripts/stocks_backfill.php --symbol=AAPL --from=2023-01-01 --to=2023-12-31
 - Rows whose type includes `BUY` or `SELL` become trades; cash top-ups/withdrawals, dividends, and interest rows are skipped automatically.
 - Fees are taken from the `Fee` column when present, otherwise we infer them from the difference between `Total Amount` and `Quantity × Price`.
 - After uploading, the page flashes a summary including any skipped rows so you can reconcile what was imported.
+- If you need to start over, use the **Clear history** button on the import card to wipe all recorded trades, positions, realized P/L entries, and portfolio snapshots for the signed-in user.
 
 ## Cost-basis preferences
 

--- a/docs/stocks.md
+++ b/docs/stocks.md
@@ -13,6 +13,15 @@ Set the following environment variables (or edit `config/config.php`):
 
 Provider-specific settings are merged with the config array returned from `config/config.php` under the `stocks.providers` key.
 
+### Setting up Finnhub
+
+1. Create a Finnhub account at [https://finnhub.io](https://finnhub.io) and generate an API key from the dashboard.
+2. Add the key to your environment via `.env` or the hosting control panel: set `FINNHUB_API_KEY=your_key_here` and `STOCKS_PROVIDER=finnhub`.
+3. (Optional) Override the base URL with `FINNHUB_BASE_URL` if you are using a proxy or the sandbox endpoint.
+4. Clear the application cache or restart PHP-FPM/workers so the new environment variables are picked up.
+5. Run `php scripts/stocks_backfill.php --symbol=AAPL --from=$(date -d '30 days ago' +%Y-%m-%d) --to=$(date +%Y-%m-%d)` (or the equivalent for your shell) to confirm candles load.
+6. Visit `/stocks` in the UI; the live quote badges should show “fresh” timestamps and the network panel will display Finnhub API calls.
+
 ## Database
 
 Run migrations to create the new tables:

--- a/docs/stocks.md
+++ b/docs/stocks.md
@@ -8,6 +8,8 @@ Set the following environment variables (or edit `config/config.php`):
 
 - `STOCKS_PROVIDER` – provider key (`null`, `finnhub`, ...). Defaults to `null` which disables remote quotes.
 - `STOCKS_REFRESH_SECONDS` – polling interval for live quotes (default `10`).
+- `STOCKS_OVERVIEW_CACHE_SECONDS` – how long (in seconds) to reuse the cached `/stocks` overview snapshot before rebuilding it (default `20`, set to `0` to disable).
+- `STOCKS_OVERVIEW_CACHE_DIR` – directory for persisted overview cache files (defaults to `storage/cache/stocks`). Ensure the PHP process can write to it.
 - `FINNHUB_API_KEY` – required when `STOCKS_PROVIDER=finnhub`.
 - `FINNHUB_BASE_URL` – optional override for the Finnhub API base URL.
 

--- a/index.php
+++ b/index.php
@@ -42,8 +42,19 @@ if ($base !== '' && str_starts_with($rawPath, $base)) {
 }
 $path = rtrim($rawPath, '/') ?: '/';
 
+// Normalize request info for the router
+$method = strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET');           // "GET", "POST", etc.
+
+// (optional) honor method override from forms like _method=DELETE
+if ($method === 'POST' && !empty($_POST['_method'])) {
+    $override = strtoupper(trim($_POST['_method']));
+    if (in_array($override, ['PUT', 'PATCH', 'DELETE'], true)) {
+        $method = $override;
+    }
+}
+
 // Dynamic routes for stocks module
-if (preg_match('#^/stocks/([A-Za-z0-9\.-:]+)$#', $path, $m)) {
+if ($method === 'GET' && preg_match('#^/stocks/([A-Za-z0-9\.-:]+)$#', $path, $m)) {
     require_login();
     require __DIR__ . '/src/controllers/stocks.php';
     stocks_detail($pdo, $m[1]);
@@ -66,17 +77,6 @@ if (preg_match('#^/api/stocks/([A-Za-z0-9\.-:]+)/history$#', $path, $m)) {
     require __DIR__ . '/src/controllers/stocks.php';
     stocks_history_api($pdo, $m[1]);
     return;
-}
-
-// Normalize request info for the router
-$method = strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET');           // "GET", "POST", etc.
-
-// (optional) honor method override from forms like _method=DELETE
-if ($method === 'POST' && !empty($_POST['_method'])) {
-    $override = strtoupper(trim($_POST['_method']));
-    if (in_array($override, ['PUT', 'PATCH', 'DELETE'], true)) {
-        $method = $override;
-    }
 }
 
 // Simple routing

--- a/index.php
+++ b/index.php
@@ -588,6 +588,11 @@ switch ($path) {
         require __DIR__ . '/src/controllers/stocks.php';
         stocks_index($pdo);
         break;
+    case '/stocks/transactions':
+        require_login();
+        require __DIR__ . '/src/controllers/stocks.php';
+        stocks_transactions($pdo);
+        break;
     case '/stocks/trade':
         require_login();
         require __DIR__ . '/src/controllers/stocks.php';

--- a/index.php
+++ b/index.php
@@ -605,6 +605,14 @@ switch ($path) {
         }
         redirect('/stocks');
         break;
+    case '/stocks/clear':
+        require_login();
+        require __DIR__ . '/src/controllers/stocks.php';
+        if ($method === 'POST') {
+            stocks_clear_history($pdo);
+        }
+        redirect('/stocks');
+        break;
     case '/stocks/trade/delete':
         require_login();
         require __DIR__ . '/src/controllers/stocks.php';

--- a/index.php
+++ b/index.php
@@ -597,6 +597,14 @@ switch ($path) {
             redirect('/stocks');
         }
         break;
+    case '/stocks/import':
+        require_login();
+        require __DIR__ . '/src/controllers/stocks.php';
+        if ($method === 'POST') {
+            stocks_import($pdo);
+        }
+        redirect('/stocks');
+        break;
     case '/stocks/trade/delete':
         require_login();
         require __DIR__ . '/src/controllers/stocks.php';

--- a/index.php
+++ b/index.php
@@ -623,7 +623,9 @@ switch ($path) {
         require __DIR__ . '/src/controllers/stocks.php';
         if ($method === 'POST') {
             $target = stocks_refresh_overview($pdo);
-            redirect($target);
+            if ($target !== null) {
+                redirect($target);
+            }
         } else {
             redirect('/stocks');
         }

--- a/index.php
+++ b/index.php
@@ -42,6 +42,32 @@ if ($base !== '' && str_starts_with($rawPath, $base)) {
 }
 $path = rtrim($rawPath, '/') ?: '/';
 
+// Dynamic routes for stocks module
+if (preg_match('#^/stocks/([A-Za-z0-9\.-:]+)$#', $path, $m)) {
+    require_login();
+    require __DIR__ . '/src/controllers/stocks.php';
+    stocks_detail($pdo, $m[1]);
+    return;
+}
+
+if (preg_match('#^/stocks/([A-Za-z0-9\.-:]+)/watch$#', $path, $m)) {
+    require_login();
+    require __DIR__ . '/src/controllers/stocks.php';
+    if ($method === 'POST') {
+        stocks_toggle_watch($pdo, $m[1]);
+    } else {
+        redirect('/stocks/' . urlencode($m[1]));
+    }
+    return;
+}
+
+if (preg_match('#^/api/stocks/([A-Za-z0-9\.-:]+)/history$#', $path, $m)) {
+    require_login();
+    require __DIR__ . '/src/controllers/stocks.php';
+    stocks_history_api($pdo, $m[1]);
+    return;
+}
+
 // Normalize request info for the router
 $method = strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET');           // "GET", "POST", etc.
 
@@ -562,23 +588,27 @@ switch ($path) {
         require __DIR__ . '/src/controllers/stocks.php';
         stocks_index($pdo);
         break;
-    case '/stocks/buy':
+    case '/stocks/trade':
         require_login();
         require __DIR__ . '/src/controllers/stocks.php';
-        if ($_SERVER['REQUEST_METHOD'] === 'POST') { trade_buy($pdo); }
-        redirect('/stocks');
-        break;
-    case '/stocks/sell':
-        require_login();
-        require __DIR__ . '/src/controllers/stocks.php';
-        if ($_SERVER['REQUEST_METHOD'] === 'POST') { trade_sell($pdo); }
-        redirect('/stocks');
+        if ($method === 'POST') {
+            stocks_trade($pdo);
+        } else {
+            redirect('/stocks');
+        }
         break;
     case '/stocks/trade/delete':
         require_login();
         require __DIR__ . '/src/controllers/stocks.php';
-        if ($_SERVER['REQUEST_METHOD'] === 'POST') { trade_delete($pdo); }
+        if ($method === 'POST') {
+            stocks_delete_trade($pdo);
+        }
         redirect('/stocks');
+        break;
+    case '/api/stocks/live':
+        require_login();
+        require __DIR__ . '/src/controllers/stocks.php';
+        stocks_live_api($pdo);
         break;
 
     // Scheduled

--- a/index.php
+++ b/index.php
@@ -605,6 +605,14 @@ switch ($path) {
         }
         redirect('/stocks');
         break;
+    case '/stocks/cash':
+        require_login();
+        require __DIR__ . '/src/controllers/stocks.php';
+        if ($method === 'POST') {
+            stocks_cash_movement($pdo);
+        }
+        redirect('/stocks');
+        break;
     case '/stocks/clear':
         require_login();
         require __DIR__ . '/src/controllers/stocks.php';

--- a/index.php
+++ b/index.php
@@ -55,10 +55,14 @@ if ($method === 'POST' && !empty($_POST['_method'])) {
 
 // Dynamic routes for stocks module
 if ($method === 'GET' && preg_match('#^/stocks/([A-Za-z0-9\.-:]+)$#', $path, $m)) {
-    require_login();
-    require __DIR__ . '/src/controllers/stocks.php';
-    stocks_detail($pdo, $m[1]);
-    return;
+    $slug = strtolower($m[1]);
+    $reserved = ['transactions', 'trade', 'import', 'cash', 'refresh', 'clear'];
+    if (!in_array($slug, $reserved, true)) {
+        require_login();
+        require __DIR__ . '/src/controllers/stocks.php';
+        stocks_detail($pdo, $m[1]);
+        return;
+    }
 }
 
 if (preg_match('#^/stocks/([A-Za-z0-9\.-:]+)/watch$#', $path, $m)) {

--- a/index.php
+++ b/index.php
@@ -618,6 +618,16 @@ switch ($path) {
         }
         redirect('/stocks');
         break;
+    case '/stocks/refresh':
+        require_login();
+        require __DIR__ . '/src/controllers/stocks.php';
+        if ($method === 'POST') {
+            $target = stocks_refresh_overview($pdo);
+            redirect($target);
+        } else {
+            redirect('/stocks');
+        }
+        break;
     case '/stocks/clear':
         require_login();
         require __DIR__ . '/src/controllers/stocks.php';

--- a/migrations/011_stocks_overhaul.sql
+++ b/migrations/011_stocks_overhaul.sql
@@ -1,5 +1,8 @@
 BEGIN;
 
+-- Drop legacy view early so subsequent column alterations don't fail
+DROP VIEW IF EXISTS v_stock_positions;
+
 -- Core stocks master data
 CREATE TABLE IF NOT EXISTS stocks (
   id SERIAL PRIMARY KEY,
@@ -45,6 +48,8 @@ ALTER TABLE stock_trades ALTER COLUMN executed_at SET NOT NULL;
 ALTER TABLE stock_trades ALTER COLUMN side TYPE TEXT;
 ALTER TABLE stock_trades ALTER COLUMN side SET NOT NULL;
 ALTER TABLE stock_trades ALTER COLUMN stock_id SET NOT NULL;
+
+-- Legacy view is intentionally left removed; the new services replace it
 
 -- Richer portfolio state tables
 CREATE TABLE IF NOT EXISTS stock_positions (
@@ -142,8 +147,5 @@ CREATE TABLE IF NOT EXISTS stock_portfolio_snapshots (
   created_at TIMESTAMPTZ DEFAULT NOW(),
   UNIQUE(user_id, snapshot_on)
 );
-
--- Drop legacy view replaced by service managed tables
-DROP VIEW IF EXISTS v_stock_positions;
 
 COMMIT;

--- a/migrations/011_stocks_overhaul.sql
+++ b/migrations/011_stocks_overhaul.sql
@@ -1,0 +1,149 @@
+BEGIN;
+
+-- Core stocks master data
+CREATE TABLE IF NOT EXISTS stocks (
+  id SERIAL PRIMARY KEY,
+  symbol TEXT NOT NULL,
+  exchange TEXT,
+  market TEXT,
+  name TEXT,
+  currency TEXT REFERENCES currencies(code),
+  sector TEXT,
+  industry TEXT,
+  beta NUMERIC(10,4),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stocks_symbol_market ON stocks (UPPER(symbol), COALESCE(market, ''));
+
+-- Extend stock_trades with richer metadata
+ALTER TABLE stock_trades
+  ADD COLUMN IF NOT EXISTS stock_id INT REFERENCES stocks(id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS executed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS fee NUMERIC(18,4) DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS note TEXT,
+  ADD COLUMN IF NOT EXISTS market TEXT,
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW(),
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;
+
+UPDATE stock_trades SET executed_at = COALESCE(executed_at, trade_on::timestamptz);
+
+-- Backfill stocks table from historic trades
+INSERT INTO stocks(symbol, market, name, currency)
+SELECT DISTINCT UPPER(symbol) AS symbol, COALESCE(market, 'US') AS market, UPPER(symbol) AS name, COALESCE(currency, 'USD')
+FROM stock_trades
+ON CONFLICT (UPPER(symbol), COALESCE(market, '')) DO NOTHING;
+
+UPDATE stock_trades st
+SET stock_id = s.id
+FROM stocks s
+WHERE st.stock_id IS NULL AND UPPER(st.symbol) = UPPER(s.symbol)
+  AND (s.market IS NULL OR st.market IS NULL OR s.market = st.market);
+
+-- Enforce not nulls after backfill
+ALTER TABLE stock_trades ALTER COLUMN executed_at SET NOT NULL;
+ALTER TABLE stock_trades ALTER COLUMN side TYPE TEXT;
+ALTER TABLE stock_trades ALTER COLUMN side SET NOT NULL;
+ALTER TABLE stock_trades ALTER COLUMN stock_id SET NOT NULL;
+
+-- Richer portfolio state tables
+CREATE TABLE IF NOT EXISTS stock_positions (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  stock_id INT NOT NULL REFERENCES stocks(id) ON DELETE CASCADE,
+  qty NUMERIC(18,6) DEFAULT 0,
+  avg_cost_ccy NUMERIC(18,6) DEFAULT 0,
+  avg_cost_currency TEXT,
+  cash_impact_ccy NUMERIC(20,6) DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(user_id, stock_id)
+);
+CREATE INDEX IF NOT EXISTS idx_stock_positions_user_qty ON stock_positions(user_id) WHERE qty <> 0;
+
+CREATE TABLE IF NOT EXISTS stock_lots (
+  id SERIAL PRIMARY KEY,
+  position_id INT NOT NULL REFERENCES stock_positions(id) ON DELETE CASCADE,
+  qty_open NUMERIC(18,6) NOT NULL,
+  qty_closed NUMERIC(18,6) DEFAULT 0,
+  open_price NUMERIC(18,6) NOT NULL,
+  fee NUMERIC(18,4) DEFAULT 0,
+  opened_at TIMESTAMPTZ NOT NULL,
+  closed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_stock_lots_position_opened ON stock_lots(position_id, opened_at);
+
+CREATE TABLE IF NOT EXISTS stock_realized_pl (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  stock_id INT NOT NULL REFERENCES stocks(id) ON DELETE CASCADE,
+  sell_trade_id INT REFERENCES stock_trades(id) ON DELETE CASCADE,
+  realized_pl_base NUMERIC(20,6) NOT NULL,
+  realized_pl_ccy NUMERIC(20,6) NOT NULL,
+  currency TEXT,
+  method TEXT DEFAULT 'FIFO',
+  qty_closed NUMERIC(18,6) NOT NULL,
+  closed_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_stock_realized_pl_user_date ON stock_realized_pl(user_id, closed_at);
+
+CREATE TABLE IF NOT EXISTS stock_prices_last (
+  stock_id INT PRIMARY KEY REFERENCES stocks(id) ON DELETE CASCADE,
+  last NUMERIC(18,6),
+  prev_close NUMERIC(18,6),
+  day_high NUMERIC(18,6),
+  day_low NUMERIC(18,6),
+  volume NUMERIC(18,2),
+  provider_ts TIMESTAMPTZ,
+  stale BOOLEAN DEFAULT FALSE,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS price_daily (
+  id SERIAL PRIMARY KEY,
+  stock_id INT NOT NULL REFERENCES stocks(id) ON DELETE CASCADE,
+  date DATE NOT NULL,
+  open NUMERIC(18,6),
+  high NUMERIC(18,6),
+  low NUMERIC(18,6),
+  close NUMERIC(18,6),
+  volume NUMERIC(18,2),
+  provider TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(stock_id, date)
+);
+CREATE INDEX IF NOT EXISTS idx_price_daily_stock_date ON price_daily(stock_id, date DESC);
+
+CREATE TABLE IF NOT EXISTS watchlist (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  stock_id INT NOT NULL REFERENCES stocks(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(user_id, stock_id)
+);
+
+CREATE TABLE IF NOT EXISTS user_settings_stocks (
+  user_id INT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  unrealized_method TEXT DEFAULT 'AVERAGE',
+  realized_method TEXT DEFAULT 'FIFO',
+  target_allocations JSONB,
+  refresh_seconds INT DEFAULT 10
+);
+
+-- Helper cache for quick totals
+CREATE TABLE IF NOT EXISTS stock_portfolio_snapshots (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  snapshot_on DATE NOT NULL,
+  total_value_base NUMERIC(20,6) NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(user_id, snapshot_on)
+);
+
+-- Drop legacy view replaced by service managed tables
+DROP VIEW IF EXISTS v_stock_positions;
+
+COMMIT;

--- a/migrations/012_stock_cash_movements.sql
+++ b/migrations/012_stock_cash_movements.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS stock_cash_movements (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    amount NUMERIC(18, 2) NOT NULL,
+    currency CHAR(3) NOT NULL,
+    executed_at TIMESTAMPTZ NOT NULL,
+    note TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS stock_cash_movements_user_idx ON stock_cash_movements(user_id);
+CREATE INDEX IF NOT EXISTS stock_cash_movements_executed_idx ON stock_cash_movements(executed_at);
+
+COMMIT;

--- a/scripts/stocks_backfill.php
+++ b/scripts/stocks_backfill.php
@@ -1,0 +1,38 @@
+<?php
+require __DIR__ . '/../config/load_env.php';
+$config = require __DIR__ . '/../config/config.php';
+require __DIR__ . '/../config/db.php';
+require __DIR__ . '/../src/stocks/PriceProviderAdapter.php';
+require __DIR__ . '/../src/stocks/Adapters/NullPriceProvider.php';
+require __DIR__ . '/../src/stocks/Adapters/FinnhubAdapter.php';
+require __DIR__ . '/../src/stocks/PriceDataService.php';
+
+use Stocks\Adapters\FinnhubAdapter;
+use Stocks\Adapters\NullPriceProvider;
+use Stocks\PriceDataService;
+
+$options = getopt('', ['symbol:', 'from::', 'to::']);
+$symbol = isset($options['symbol']) ? strtoupper(trim($options['symbol'])) : null;
+if (!$symbol) {
+    fwrite(STDERR, "Usage: php scripts/stocks_backfill.php --symbol=TICKER [--from=YYYY-MM-DD] [--to=YYYY-MM-DD]\n");
+    exit(1);
+}
+$from = $options['from'] ?? date('Y-m-d', strtotime('-6 months'));
+$to = $options['to'] ?? date('Y-m-d');
+
+$providerName = strtolower($config['stocks']['provider'] ?? 'null');
+$adapter = new NullPriceProvider();
+if ($providerName === 'finnhub') {
+    $providerCfg = $config['stocks']['providers']['finnhub'] ?? [];
+    $apiKey = $providerCfg['api_key'] ?? getenv('FINNHUB_API_KEY');
+    $baseUrl = $providerCfg['base_url'] ?? getenv('FINNHUB_BASE_URL') ?: 'https://finnhub.io/api/v1';
+    if (!empty($apiKey)) {
+        $adapter = new FinnhubAdapter($apiKey, $baseUrl);
+    }
+}
+
+$ttl = (int)($config['stocks']['refresh_seconds'] ?? 10);
+$service = new PriceDataService($pdo, $adapter, $ttl);
+
+$candles = $service->getDailyHistory($symbol, $from, $to);
+printf("Stored %d candles for %s (%s → %s)\n", count($candles), $symbol, $from, $to);

--- a/scripts/stocks_rebuild.php
+++ b/scripts/stocks_rebuild.php
@@ -1,0 +1,37 @@
+<?php
+require __DIR__ . '/../config/load_env.php';
+$config = require __DIR__ . '/../config/config.php';
+require __DIR__ . '/../config/db.php';
+require __DIR__ . '/../src/stocks/TradeService.php';
+
+$options = getopt('', ['user::', 'symbol::']);
+$userId = isset($options['user']) ? (int)$options['user'] : null;
+$symbol = isset($options['symbol']) ? strtoupper(trim($options['symbol'])) : null;
+
+$tradeService = new Stocks\TradeService($pdo);
+
+if ($userId && $symbol) {
+    $stockId = $pdo->prepare('SELECT id FROM stocks WHERE UPPER(symbol)=?');
+    $stockId->execute([$symbol]);
+    $sid = $stockId->fetchColumn();
+    if (!$sid) {
+        fwrite(STDERR, "Unknown symbol $symbol\n");
+        exit(1);
+    }
+    $tradeService->rebuildPositions($userId, (int)$sid);
+    echo "Rebuilt positions for user {$userId}, symbol {$symbol}\n";
+    exit(0);
+}
+
+if ($userId) {
+    $tradeService->rebuildPositions($userId);
+    echo "Rebuilt all stocks for user {$userId}\n";
+    exit(0);
+}
+
+$users = $pdo->query('SELECT id FROM users')->fetchAll(PDO::FETCH_COLUMN);
+foreach ($users as $uid) {
+    $tradeService->rebuildPositions((int)$uid);
+}
+
+echo "Rebuilt positions for " . count($users) . " users\n";

--- a/src/controllers/stocks.php
+++ b/src/controllers/stocks.php
@@ -209,7 +209,7 @@ function stocks_import(PDO $pdo): void
     }
 
     $columnMap = stocks_import_header_map($headerRow);
-    if (empty($columnMap['date']) || empty($columnMap['type'])) {
+    if (!array_key_exists('date', $columnMap) || !array_key_exists('type', $columnMap)) {
         fclose($handle);
         $_SESSION['flash'] = 'The CSV is missing required headers (Date / Type).';
         return;

--- a/src/controllers/stocks.php
+++ b/src/controllers/stocks.php
@@ -11,13 +11,13 @@ require_once __DIR__ . '/../stocks/TradeService.php';
 require_once __DIR__ . '/../stocks/SignalsService.php';
 require_once __DIR__ . '/../stocks/ChartsService.php';
 
-use Stocks\\Adapters\\FinnhubAdapter;
-use Stocks\\Adapters\\NullPriceProvider;
-use Stocks\\ChartsService;
-use Stocks\\PortfolioService;
-use Stocks\\PriceDataService;
-use Stocks\\SignalsService;
-use Stocks\\TradeService;
+use Stocks\Adapters\FinnhubAdapter;
+use Stocks\Adapters\NullPriceProvider;
+use Stocks\ChartsService;
+use Stocks\PortfolioService;
+use Stocks\PriceDataService;
+use Stocks\SignalsService;
+use Stocks\TradeService;
 
 function stocks_index(PDO $pdo): void
 {
@@ -97,7 +97,7 @@ function stocks_detail(PDO $pdo, string $symbol): void
 
     $positionSeries = $chartsService->positionValueSeries($userId, $symbol, $historyRange);
 
-    $realizedStmt = $pdo->prepare('SELECT COALESCE(SUM(realized_pl_base),0) FROM stock_realized_pl WHERE user_id=? AND stock_id=? AND DATE_TRUNC(''year'', closed_at)=DATE_TRUNC(''year'', CURRENT_DATE)');
+    $realizedStmt = $pdo->prepare('SELECT COALESCE(SUM(realized_pl_base),0) FROM stock_realized_pl WHERE user_id=? AND stock_id=? AND DATE_TRUNC(\'year\', closed_at)=DATE_TRUNC(\'year\', CURRENT_DATE)');
     $realizedStmt->execute([$userId, $stockRow['id']]);
     $realizedYtd = (float)$realizedStmt->fetchColumn();
 

--- a/src/controllers/stocks.php
+++ b/src/controllers/stocks.php
@@ -1,36 +1,296 @@
 <?php
+
 require_once __DIR__ . '/../helpers.php';
+require_once __DIR__ . '/../fx.php';
+require_once __DIR__ . '/../stocks/PriceProviderAdapter.php';
+require_once __DIR__ . '/../stocks/Adapters/NullPriceProvider.php';
+require_once __DIR__ . '/../stocks/Adapters/FinnhubAdapter.php';
+require_once __DIR__ . '/../stocks/PriceDataService.php';
+require_once __DIR__ . '/../stocks/PortfolioService.php';
+require_once __DIR__ . '/../stocks/TradeService.php';
+require_once __DIR__ . '/../stocks/SignalsService.php';
+require_once __DIR__ . '/../stocks/ChartsService.php';
 
-function stocks_index(PDO $pdo){ require_login(); $u=uid();
-  // Open positions & cost basis (from view)
-  $pos=$pdo->prepare('SELECT symbol, qty, avg_buy_price FROM v_stock_positions WHERE user_id=? ORDER BY symbol');
-  $pos->execute([$u]); $positions=$pos->fetchAll();
+use Stocks\\Adapters\\FinnhubAdapter;
+use Stocks\\Adapters\\NullPriceProvider;
+use Stocks\\ChartsService;
+use Stocks\\PortfolioService;
+use Stocks\\PriceDataService;
+use Stocks\\SignalsService;
+use Stocks\\TradeService;
 
-  // Portfolio cost basis value (qty * avg_buy_price for qty>0)
-  $portfolio_value = 0.0; foreach($positions as $p){ if((float)$p['qty']>0){ $portfolio_value += (float)$p['qty'] * (float)$p['avg_buy_price']; } }
+function stocks_index(PDO $pdo): void
+{
+    require_login();
+    $userId = uid();
+    $priceService = stocks_price_service($pdo);
+    $portfolio = new PortfolioService($pdo, $priceService);
+    $signalsService = new SignalsService($pdo, $priceService);
+    $chartsService = new ChartsService($pdo, $priceService);
 
-  // Recent trades
-  $t=$pdo->prepare('SELECT * FROM stock_trades WHERE user_id=? ORDER BY trade_on DESC, id DESC LIMIT 100');
-  $t->execute([$u]); $trades=$t->fetchAll();
+    $filters = [
+        'search' => $_GET['q'] ?? null,
+        'sector' => $_GET['sector'] ?? null,
+        'currency' => $_GET['currency'] ?? null,
+        'watchlist_only' => !empty($_GET['watchlist']),
+        'realized_period' => $_GET['period'] ?? null,
+    ];
+    $overview = $portfolio->buildOverview($userId, $filters);
+    $holdings = $overview['holdings'];
+    $totals = $overview['totals'] + ['user_id' => $userId, 'default_target' => 10.0];
 
-  view('stocks/index', compact('positions','portfolio_value','trades'));
+    $insights = [];
+    foreach ($holdings as $holding) {
+        $insights[$holding['symbol']] = $signalsService->analyze($userId, $holding, ['prev_close' => $holding['prev_close'] ?? null], $totals);
+    }
+
+    $portfolioChart = $chartsService->portfolioValueSeries($userId, $_GET['chartRange'] ?? '6M');
+    $refreshSeconds = stocks_refresh_seconds($userId, $pdo);
+
+    view('stocks/index', [
+        'overview' => $overview,
+        'insights' => $insights,
+        'portfolioChart' => $portfolioChart,
+        'filters' => $filters,
+        'refreshSeconds' => $refreshSeconds,
+    ]);
 }
 
-function trade_buy(PDO $pdo){ verify_csrf(); require_login(); $u=uid();
-  $stmt=$pdo->prepare('INSERT INTO stock_trades(user_id,symbol,trade_on,side,quantity,price,currency) VALUES(?,?,?,?,?,?,?)');
-  $stmt->execute([$u, strtoupper(trim($_POST['symbol'])), $_POST['trade_on'] ?: date('Y-m-d'), 'buy', (float)$_POST['quantity'], (float)$_POST['price'], $_POST['currency'] ?: 'USD']);
+function stocks_detail(PDO $pdo, string $symbol): void
+{
+    require_login();
+    $userId = uid();
+    $symbol = strtoupper($symbol);
+    $priceService = stocks_price_service($pdo);
+    $signalsService = new SignalsService($pdo, $priceService);
+    $chartsService = new ChartsService($pdo, $priceService);
+
+    $stockRow = stocks_fetch_stock($pdo, $symbol);
+    if (!$stockRow) {
+        http_response_code(404);
+        view('errors/404');
+        return;
+    }
+
+    $baseCurrency = fx_user_main($pdo, $userId);
+    $positionStmt = $pdo->prepare('SELECT sp.*, s.name, s.symbol, s.currency FROM stock_positions sp JOIN stocks s ON s.id = sp.stock_id WHERE sp.user_id=? AND UPPER(s.symbol)=?');
+    $positionStmt->execute([$userId, $symbol]);
+    $position = $positionStmt->fetch(PDO::FETCH_ASSOC);
+
+    $quote = $priceService->getLiveQuotes([$symbol]);
+    $quoteRow = $quote[0] ?? null;
+    $historyRange = $_GET['range'] ?? '6M';
+    $historyBounds = stocks_history_bounds($historyRange);
+    $priceHistory = $priceService->getDailyHistory($symbol, $historyBounds['start'], $historyBounds['end']);
+
+    $holdingLike = [
+        'symbol' => $symbol,
+        'currency' => $stockRow['currency'] ?? 'USD',
+        'avg_cost' => $position['avg_cost_ccy'] ?? 0,
+        'qty' => $position['qty'] ?? 0,
+        'last_price' => $quoteRow['last'] ?? null,
+        'prev_close' => $quoteRow['prev_close'] ?? null,
+        'weight_pct' => $position && ($position['qty'] ?? 0) > 0 ? 0.0 : 0.0,
+    ];
+    $totals = ['user_id' => $userId, 'default_target' => 10.0];
+    $insights = $signalsService->analyze($userId, $holdingLike, ['prev_close' => $quoteRow['prev_close'] ?? null], $totals);
+
+    $positionSeries = $chartsService->positionValueSeries($userId, $symbol, $historyRange);
+
+    $realizedStmt = $pdo->prepare('SELECT COALESCE(SUM(realized_pl_base),0) FROM stock_realized_pl WHERE user_id=? AND stock_id=? AND DATE_TRUNC(''year'', closed_at)=DATE_TRUNC(''year'', CURRENT_DATE)');
+    $realizedStmt->execute([$userId, $stockRow['id']]);
+    $realizedYtd = (float)$realizedStmt->fetchColumn();
+
+    $settings = stocks_settings($pdo, $userId);
+    $isWatched = stocks_is_watched($pdo, $userId, (int)$stockRow['id']);
+
+    view('stocks/show', [
+        'stock' => $stockRow,
+        'position' => $position,
+        'quote' => $quoteRow,
+        'priceHistory' => $priceHistory,
+        'insights' => $insights,
+        'positionSeries' => $positionSeries,
+        'realizedYtd' => $realizedYtd,
+        'settings' => $settings,
+        'isWatched' => $isWatched,
+        'historyRange' => $historyRange,
+        'baseCurrency' => $baseCurrency,
+    ]);
 }
 
-function trade_sell(PDO $pdo){ verify_csrf(); require_login(); $u=uid();
-  // Optional naive check: prevent selling more than held (best-effort; DB view handles net qty anyway)
-  $symbol = strtoupper(trim($_POST['symbol'])); $qty=(float)$_POST['quantity'];
-  $q=$pdo->prepare('SELECT qty FROM v_stock_positions WHERE user_id=? AND symbol=?'); $q->execute([$u,$symbol]); $held=(float)($q->fetchColumn() ?: 0);
-  if ($qty > $held) { $qty = $held; }
-  if ($qty <= 0) { return; }
-  $pdo->prepare('INSERT INTO stock_trades(user_id,symbol,trade_on,side,quantity,price,currency) VALUES(?,?,?,?,?,?,?)')
-      ->execute([$u, $symbol, $_POST['trade_on'] ?: date('Y-m-d'), 'sell', $qty, (float)$_POST['price'], $_POST['currency'] ?: 'USD']);
+function stocks_trade(PDO $pdo): void
+{
+    verify_csrf();
+    require_login();
+    $userId = uid();
+    $tradeService = new TradeService($pdo);
+    $side = strtoupper($_POST['side'] ?? '');
+    $symbol = strtoupper(trim($_POST['symbol'] ?? ''));
+    $quantity = (float)($_POST['quantity'] ?? 0);
+    $price = (float)($_POST['price'] ?? 0);
+    $currency = $_POST['currency'] ?? 'USD';
+    $fee = isset($_POST['fee']) ? (float)$_POST['fee'] : 0.0;
+    $date = $_POST['trade_date'] ?? date('Y-m-d');
+    $time = $_POST['trade_time'] ?? '15:30:00';
+    $note = $_POST['note'] ?? null;
+    $market = $_POST['market'] ?? null;
+    $executedAt = trim($date . ' ' . $time);
+
+    $payload = [
+        'symbol' => $symbol,
+        'side' => $side,
+        'quantity' => $quantity,
+        'price' => $price,
+        'currency' => $currency,
+        'fee' => $fee,
+        'executed_at' => $executedAt,
+        'note' => $note,
+        'market' => $market,
+    ];
+    try {
+        $tradeService->recordTrade($userId, $payload);
+        redirect('/stocks/' . urlencode($symbol));
+    } catch (Throwable $e) {
+        error_log('[stocks_trade] ' . $e->getMessage());
+        redirect('/stocks?error=trade');
+    }
 }
 
-function trade_delete(PDO $pdo){ verify_csrf(); require_login(); $u=uid();
-  $pdo->prepare('DELETE FROM stock_trades WHERE id=? AND user_id=?')->execute([(int)$_POST['id'],$u]);
+function stocks_delete_trade(PDO $pdo): void
+{
+    verify_csrf();
+    require_login();
+    $userId = uid();
+    $tradeId = (int)($_POST['id'] ?? 0);
+    if ($tradeId <= 0) {
+        redirect('/stocks');
+        return;
+    }
+    $tradeService = new TradeService($pdo);
+    $tradeService->deleteTrade($userId, $tradeId);
+    redirect('/stocks');
+}
+
+function stocks_toggle_watch(PDO $pdo, string $symbol): void
+{
+    verify_csrf();
+    require_login();
+    $userId = uid();
+    $stock = stocks_fetch_stock($pdo, strtoupper($symbol));
+    if (!$stock) {
+        redirect('/stocks/' . urlencode($symbol));
+        return;
+    }
+    $existsStmt = $pdo->prepare('SELECT id FROM watchlist WHERE user_id=? AND stock_id=?');
+    $existsStmt->execute([$userId, $stock['id']]);
+    $exists = $existsStmt->fetchColumn();
+    if ($exists) {
+        $pdo->prepare('DELETE FROM watchlist WHERE id=?')->execute([$exists]);
+    } else {
+        $pdo->prepare('INSERT INTO watchlist(user_id, stock_id, created_at) VALUES(?,?, NOW()) ON CONFLICT DO NOTHING')->execute([$userId, $stock['id']]);
+    }
+    redirect('/stocks/' . urlencode($symbol));
+}
+
+function stocks_live_api(PDO $pdo): void
+{
+    require_login();
+    $symbolsParam = $_GET['symbols'] ?? '';
+    $symbols = array_filter(array_map('trim', explode(',', $symbolsParam)));
+    $priceService = stocks_price_service($pdo);
+    $quotes = $priceService->getLiveQuotes($symbols);
+    json_response(['quotes' => $quotes]);
+}
+
+function stocks_history_api(PDO $pdo, string $symbol): void
+{
+    require_login();
+    $range = $_GET['range'] ?? '6M';
+    $priceService = stocks_price_service($pdo);
+    $bounds = stocks_history_bounds($range);
+    $priceHistory = $priceService->getDailyHistory(strtoupper($symbol), $bounds['start'], $bounds['end']);
+    $chartsService = new ChartsService($pdo, $priceService);
+    $series = $chartsService->positionValueSeries(uid(), strtoupper($symbol), $range);
+    json_response([
+        'price' => $priceHistory,
+        'position' => $series,
+    ]);
+}
+
+/**
+ * @return array{start: string, end: string}
+ */
+function stocks_history_bounds(string $range): array
+{
+    $range = strtoupper($range);
+    $end = date('Y-m-d');
+    $start = match ($range) {
+        '1D' => date('Y-m-d', strtotime('-1 day')),
+        '5D' => date('Y-m-d', strtotime('-5 days')),
+        '1M' => date('Y-m-d', strtotime('-1 month')),
+        '6M' => date('Y-m-d', strtotime('-6 months')),
+        '1Y' => date('Y-m-d', strtotime('-1 year')),
+        '5Y' => date('Y-m-d', strtotime('-5 years')),
+        default => date('Y-m-d', strtotime('-6 months')),
+    };
+
+    return ['start' => $start, 'end' => $end];
+}
+
+function stocks_price_service(PDO $pdo): PriceDataService
+{
+    static $service;
+    if ($service) {
+        return $service;
+    }
+    global $config;
+    $providerName = strtolower($config['stocks']['provider'] ?? 'null');
+    $adapter = new NullPriceProvider();
+    if ($providerName === 'finnhub') {
+        $providerCfg = $config['stocks']['providers']['finnhub'] ?? [];
+        $apiKey = $providerCfg['api_key'] ?? getenv('FINNHUB_API_KEY');
+        $baseUrl = $providerCfg['base_url'] ?? getenv('FINNHUB_BASE_URL') ?: 'https://finnhub.io/api/v1';
+        if (!empty($apiKey)) {
+            $adapter = new FinnhubAdapter($apiKey, $baseUrl);
+        }
+    }
+    $ttl = (int)($config['stocks']['refresh_seconds'] ?? 10);
+    $service = new PriceDataService($pdo, $adapter, $ttl);
+    return $service;
+}
+
+function stocks_refresh_seconds(int $userId, PDO $pdo): int
+{
+    $stmt = $pdo->prepare('SELECT refresh_seconds FROM user_settings_stocks WHERE user_id=?');
+    $stmt->execute([$userId]);
+    $value = (int)($stmt->fetchColumn() ?: 0);
+    if ($value <= 0) {
+        global $config;
+        $value = (int)($config['stocks']['refresh_seconds'] ?? 10);
+    }
+    return max(5, $value);
+}
+
+function stocks_settings(PDO $pdo, int $userId): array
+{
+    $stmt = $pdo->prepare('SELECT * FROM user_settings_stocks WHERE user_id=?');
+    $stmt->execute([$userId]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    return $row ?: ['unrealized_method' => 'AVERAGE', 'realized_method' => 'FIFO'];
+}
+
+function stocks_fetch_stock(PDO $pdo, string $symbol): ?array
+{
+    $stmt = $pdo->prepare('SELECT * FROM stocks WHERE UPPER(symbol)=? LIMIT 1');
+    $stmt->execute([$symbol]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    return $row ?: null;
+}
+
+function stocks_is_watched(PDO $pdo, int $userId, int $stockId): bool
+{
+    $stmt = $pdo->prepare('SELECT 1 FROM watchlist WHERE user_id=? AND stock_id=?');
+    $stmt->execute([$userId, $stockId]);
+    return (bool)$stmt->fetchColumn();
 }

--- a/src/controllers/stocks.php
+++ b/src/controllers/stocks.php
@@ -1007,6 +1007,17 @@ function stocks_overview_cache_settings(): array
     return ['dir' => $dir, 'ttl' => $ttl];
 }
 
+function stocks_performance_log_path(): ?string
+{
+    global $config;
+    $path = $config['stocks']['performance_log'] ?? null;
+    if (!is_string($path) || trim($path) === '') {
+        return null;
+    }
+
+    return $path;
+}
+
 function stocks_portfolio_service(PDO $pdo): PortfolioService
 {
     static $service;
@@ -1017,7 +1028,8 @@ function stocks_portfolio_service(PDO $pdo): PortfolioService
     $priceService = stocks_price_service($pdo);
     $cashService = new CashService($pdo);
     $settings = stocks_overview_cache_settings();
-    $service = new PortfolioService($pdo, $priceService, $cashService, $settings['dir'], $settings['ttl']);
+    $logPath = stocks_performance_log_path();
+    $service = new PortfolioService($pdo, $priceService, $cashService, $settings['dir'], $settings['ttl'], $logPath);
     return $service;
 }
 

--- a/src/controllers/stocks.php
+++ b/src/controllers/stocks.php
@@ -347,11 +347,25 @@ function stocks_import(PDO $pdo): void
         }
 
         $totalAmount = stocks_import_to_float($record['total'] ?? null);
-        if ($totalAmount !== 0.0 && !isset($payload['fee'])) {
-            $notional = abs($quantity * $price);
-            $feeGuess = abs(abs($totalAmount) - $notional);
-            if ($feeGuess > 0.005) {
-                $payload['fee'] = round($feeGuess, 2);
+        if ($totalAmount !== 0.0) {
+            $cashTotal = abs($totalAmount);
+            if ($cashTotal > 0.0) {
+                $payload['cash_total'] = $cashTotal;
+            }
+
+            if (!isset($payload['fee'])) {
+                $notional = abs($quantity * $price);
+                if ($notional > 0.0 && $cashTotal > 0.0) {
+                    if ($side === 'BUY') {
+                        $feeGuess = $cashTotal - $notional;
+                    } else {
+                        $feeGuess = $notional - $cashTotal;
+                    }
+
+                    if ($feeGuess > 0.005) {
+                        $payload['fee'] = round($feeGuess, 2);
+                    }
+                }
             }
         }
 

--- a/src/controllers/stocks.php
+++ b/src/controllers/stocks.php
@@ -633,6 +633,32 @@ function stocks_cash_movement(PDO $pdo): void
     }
 }
 
+function stocks_refresh_overview(PDO $pdo): string
+{
+    verify_csrf();
+    require_login();
+    $userId = uid();
+
+    $returnTo = '/stocks';
+    $requested = $_POST['return_to'] ?? null;
+    if (is_string($requested) && str_starts_with($requested, '/')) {
+        $returnTo = $requested;
+    }
+
+    $portfolio = stocks_portfolio_service($pdo);
+
+    try {
+        $portfolio->invalidateOverviewCache($userId);
+        $portfolio->buildOverview($userId, [], false, true);
+        $_SESSION['flash_success'] = 'Quotes refreshed from the provider.';
+    } catch (Throwable $e) {
+        error_log('[stocks_refresh_overview] ' . $e->getMessage());
+        $_SESSION['flash'] = 'Unable to refresh quotes right now. Please try again.';
+    }
+
+    return $returnTo;
+}
+
 function stocks_delete_trade(PDO $pdo): void
 {
     verify_csrf();

--- a/src/controllers/stocks.php
+++ b/src/controllers/stocks.php
@@ -667,8 +667,13 @@ function stocks_refresh_overview(PDO $pdo): ?string
     $chartRange = strtoupper($_POST['chartRange'] ?? '6M');
 
     try {
+        $symbols = $portfolio->collectSymbols($userId, $filters);
+        if (!empty($symbols)) {
+            $priceService->refreshSymbols($symbols);
+        }
+
         $portfolio->invalidateOverviewCache($userId);
-        $overview = $portfolio->buildOverview($userId, $filters, false, true);
+        $overview = $portfolio->buildOverview($userId, $filters, false, false);
         $holdings = $overview['holdings'];
         $totals = $overview['totals'] + ['user_id' => $userId, 'default_target' => 10.0];
         $currencyContext = stocks_currency_breakdown($totals);

--- a/src/controllers/stocks.php
+++ b/src/controllers/stocks.php
@@ -56,6 +56,7 @@ function stocks_index(PDO $pdo): void
         'filters' => $filters,
         'refreshSeconds' => $refreshSeconds,
         'userCurrencies' => $userCurrencies,
+        'error' => $_GET['error'] ?? null,
     ]);
 }
 
@@ -160,7 +161,11 @@ function stocks_trade(PDO $pdo): void
     ];
     try {
         $tradeService->recordTrade($userId, $payload);
-        redirect('/stocks/' . urlencode($symbol));
+        $destination = '/stocks/' . urlencode($symbol);
+        if (!stocks_table_exists($pdo, 'stocks')) {
+            $destination = '/stocks';
+        }
+        redirect($destination);
     } catch (Throwable $e) {
         error_log('[stocks_trade] ' . $e->getMessage());
         redirect('/stocks?error=trade');

--- a/src/controllers/stocks.php
+++ b/src/controllers/stocks.php
@@ -506,6 +506,7 @@ function stocks_clear_history(PDO $pdo): void
             'lots' => 'lot',
             'realized' => 'realized P/L entry',
             'snapshots' => 'snapshot',
+            'cash' => 'cash ledger entry',
         ];
 
         $parts = [];

--- a/src/controllers/stocks.php
+++ b/src/controllers/stocks.php
@@ -214,6 +214,9 @@ function stocks_import(PDO $pdo): void
     require_login();
     $userId = uid();
     $wantsJson = stocks_request_wants_json();
+    if (!$wantsJson && isset($_POST['format']) && strtolower((string)$_POST['format']) === 'json') {
+        $wantsJson = true;
+    }
     $responseMeta = [
         'imported' => 0,
         'cash_recorded' => 0,

--- a/src/stocks/Adapters/FinnhubAdapter.php
+++ b/src/stocks/Adapters/FinnhubAdapter.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Stocks\Adapters;
+
+use Stocks\PriceProviderAdapter;
+
+class FinnhubAdapter implements PriceProviderAdapter
+{
+    private string $apiKey;
+    private string $baseUrl;
+
+    public function __construct(string $apiKey, string $baseUrl = 'https://finnhub.io/api/v1')
+    {
+        $this->apiKey = $apiKey;
+        $this->baseUrl = rtrim($baseUrl, '/');
+    }
+
+    public function fetchLiveQuotes(array $symbols): array
+    {
+        $out = [];
+        foreach ($symbols as $symbol) {
+            $symbol = strtoupper(trim($symbol));
+            if ($symbol === '') {
+                continue;
+            }
+            $url = sprintf('%s/quote?symbol=%s&token=%s', $this->baseUrl, rawurlencode($symbol), rawurlencode($this->apiKey));
+            $json = $this->httpGet($url);
+            if (!$json) {
+                continue;
+            }
+            $data = json_decode($json, true);
+            if (!is_array($data)) {
+                continue;
+            }
+            $out[$symbol] = [
+                'last' => isset($data['c']) ? (float)$data['c'] : null,
+                'prev_close' => isset($data['pc']) ? (float)$data['pc'] : null,
+                'high' => isset($data['h']) ? (float)$data['h'] : null,
+                'low' => isset($data['l']) ? (float)$data['l'] : null,
+                'volume' => isset($data['v']) ? (float)$data['v'] : null,
+                'currency' => $data['currency'] ?? null,
+                'provider_ts' => isset($data['t']) && $data['t'] ? date('c', (int)$data['t']) : date('c'),
+            ];
+        }
+        return $out;
+    }
+
+    public function fetchDailyHistory(string $symbol, string $from, string $to): array
+    {
+        $fromTs = strtotime($from . ' 00:00:00');
+        $toTs = strtotime($to . ' 23:59:59');
+        if (!$fromTs || !$toTs) {
+            return [];
+        }
+        $url = sprintf('%s/stock/candle?symbol=%s&resolution=D&from=%d&to=%d&token=%s',
+            $this->baseUrl,
+            rawurlencode(strtoupper($symbol)),
+            $fromTs,
+            $toTs,
+            rawurlencode($this->apiKey)
+        );
+        $json = $this->httpGet($url);
+        if (!$json) {
+            return [];
+        }
+        $data = json_decode($json, true);
+        if (!is_array($data) || ($data['s'] ?? '') !== 'ok') {
+            return [];
+        }
+        $candles = [];
+        $count = isset($data['t']) && is_array($data['t']) ? count($data['t']) : 0;
+        for ($i = 0; $i < $count; $i++) {
+            $candles[] = [
+                'date' => date('Y-m-d', (int)$data['t'][$i]),
+                'open' => isset($data['o'][$i]) ? (float)$data['o'][$i] : null,
+                'high' => isset($data['h'][$i]) ? (float)$data['h'][$i] : null,
+                'low' => isset($data['l'][$i]) ? (float)$data['l'][$i] : null,
+                'close' => isset($data['c'][$i]) ? (float)$data['c'][$i] : null,
+                'volume' => isset($data['v'][$i]) ? (float)$data['v'][$i] : null,
+            ];
+        }
+        return $candles;
+    }
+
+    public function lookupMetadata(string $symbol): array
+    {
+        $url = sprintf('%s/stock/profile2?symbol=%s&token=%s',
+            $this->baseUrl,
+            rawurlencode(strtoupper($symbol)),
+            rawurlencode($this->apiKey)
+        );
+        $json = $this->httpGet($url);
+        if (!$json) {
+            return [];
+        }
+        $data = json_decode($json, true);
+        if (!is_array($data)) {
+            return [];
+        }
+        return array_filter([
+            'name' => $data['name'] ?? null,
+            'exchange' => $data['exchange'] ?? null,
+            'currency' => $data['currency'] ?? null,
+            'sector' => $data['finnhubIndustry'] ?? null,
+            'industry' => $data['ipo'] ?? null,
+            'beta' => isset($data['beta']) ? (float)$data['beta'] : null,
+        ], static fn($value) => $value !== null && $value !== '');
+    }
+
+    private function httpGet(string $url): ?string
+    {
+        if (function_exists('curl_init')) {
+            $ch = curl_init($url);
+            curl_setopt_array($ch, [
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_CONNECTTIMEOUT => 5,
+                CURLOPT_TIMEOUT => 8,
+                CURLOPT_FOLLOWLOCATION => true,
+                CURLOPT_SSL_VERIFYPEER => true,
+                CURLOPT_USERAGENT => 'MoneyMap-Stocks/1.0'
+            ]);
+            $out = curl_exec($ch);
+            $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            curl_close($ch);
+            if ($out === false || $status !== 200) {
+                return null;
+            }
+            return $out;
+        }
+
+        $context = stream_context_create([
+            'http' => [
+                'timeout' => 8,
+                'user_agent' => 'MoneyMap-Stocks/1.0'
+            ]
+        ]);
+        $out = @file_get_contents($url, false, $context);
+        return $out !== false ? $out : null;
+    }
+}

--- a/src/stocks/Adapters/NullPriceProvider.php
+++ b/src/stocks/Adapters/NullPriceProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Stocks\Adapters;
+
+use Stocks\PriceProviderAdapter;
+
+class NullPriceProvider implements PriceProviderAdapter
+{
+    public function fetchLiveQuotes(array $symbols): array
+    {
+        $out = [];
+        $timestamp = date('c');
+        foreach ($symbols as $symbol) {
+            $out[strtoupper($symbol)] = [
+                'last' => null,
+                'prev_close' => null,
+                'high' => null,
+                'low' => null,
+                'volume' => null,
+                'currency' => null,
+                'provider_ts' => $timestamp,
+                'stale' => true,
+            ];
+        }
+        return $out;
+    }
+
+    public function fetchDailyHistory(string $symbol, string $from, string $to): array
+    {
+        return [];
+    }
+
+    public function lookupMetadata(string $symbol): array
+    {
+        return [];
+    }
+}

--- a/src/stocks/CashService.php
+++ b/src/stocks/CashService.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Stocks;
+
+use DateTime;
+use PDO;
+use PDOException;
+use RuntimeException;
+
+class CashService
+{
+    private PDO $pdo;
+
+    /**
+     * Cached flag for table existence check.
+     */
+    private ?bool $hasTable = null;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function recordMovement(int $userId, float $amount, string $currency, DateTime $executedAt, ?string $note = null): int
+    {
+        if (!$this->tableExists()) {
+            throw new RuntimeException('Stock cash movements table is missing');
+        }
+
+        $amount = round($amount, 2);
+
+        if ($amount === 0.0) {
+            throw new RuntimeException('Amount must be non-zero');
+        }
+
+        $currency = strtoupper($currency);
+        if ($currency === '') {
+            $currency = 'USD';
+        }
+
+        $stmt = $this->pdo->prepare('INSERT INTO stock_cash_movements(user_id, amount, currency, executed_at, note, created_at)
+            VALUES(?,?,?,?,?, NOW()) RETURNING id');
+        try {
+            $stmt->execute([
+                $userId,
+                $amount,
+                $currency,
+                $executedAt->format('Y-m-d H:i:sP'),
+                $note,
+            ]);
+        } catch (PDOException $e) {
+            throw new RuntimeException('Failed to record cash movement: ' . $e->getMessage(), 0, $e);
+        }
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
+     * @return array<string,float> keyed by currency code
+     */
+    public function sumByCurrency(int $userId): array
+    {
+        if (!$this->tableExists()) {
+            return [];
+        }
+
+        $stmt = $this->pdo->prepare('SELECT currency, COALESCE(SUM(amount),0) AS total
+            FROM stock_cash_movements WHERE user_id = ? GROUP BY currency');
+        $stmt->execute([$userId]);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $totals = [];
+        foreach ($rows as $row) {
+            $currency = strtoupper($row['currency'] ?? '');
+            if ($currency === '') {
+                $currency = 'USD';
+            }
+            $totals[$currency] = (float)$row['total'];
+        }
+        return $totals;
+    }
+
+    private function tableExists(): bool
+    {
+        if ($this->hasTable !== null) {
+            return $this->hasTable;
+        }
+
+        $stmt = $this->pdo->prepare("SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = ?");
+        $stmt->execute(['stock_cash_movements']);
+        $this->hasTable = (bool)$stmt->fetchColumn();
+        return $this->hasTable;
+    }
+}

--- a/src/stocks/ChartsService.php
+++ b/src/stocks/ChartsService.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Stocks;
+
+use DateInterval;
+use DatePeriod;
+use DateTime;
+use PDO;
+
+class ChartsService
+{
+    private PDO $pdo;
+    private PriceDataService $priceDataService;
+
+    public function __construct(PDO $pdo, PriceDataService $priceDataService)
+    {
+        $this->pdo = $pdo;
+        $this->priceDataService = $priceDataService;
+    }
+
+    /**
+     * @return array{labels:array<int,string>,series:array<int,float>}
+     */
+    public function portfolioValueSeries(int $userId, string $range = '1M'): array
+    {
+        $dates = $this->dateRangeFor($range);
+        $stocks = $this->loadUserStocks($userId);
+        if (empty($stocks)) {
+            return ['labels' => [], 'series' => []];
+        }
+        require_once __DIR__ . '/../fx.php';
+        $base = fx_user_main($this->pdo, $userId);
+        $historyBySymbol = [];
+        foreach ($stocks as $symbol => $info) {
+            $historyBySymbol[$symbol] = $this->indexHistory($this->priceDataService->getDailyHistory($symbol, $dates['start'], $dates['end']));
+        }
+
+        $trades = $this->loadTrades($userId, $dates['end']);
+        $positionQty = array_fill_keys(array_keys($stocks), 0.0);
+        $series = [];
+        $labels = [];
+        $tradeIdx = 0;
+        foreach ($this->iterateDates($dates['start'], $dates['end']) as $date) {
+            while ($tradeIdx < count($trades) && $trades[$tradeIdx]['date'] <= $date) {
+                $trade = $trades[$tradeIdx];
+                $symbol = $trade['symbol'];
+                $qty = (float)$trade['quantity'];
+                if ($trade['side'] === 'buy') {
+                    $positionQty[$symbol] += $qty;
+                } else {
+                    $positionQty[$symbol] -= $qty;
+                }
+                $tradeIdx++;
+            }
+            $portfolioValue = 0.0;
+            foreach ($positionQty as $symbol => $qty) {
+                if ($qty <= 0) {
+                    continue;
+                }
+                $close = $historyBySymbol[$symbol][$date]['close'] ?? null;
+                if ($close !== null) {
+                    $currency = $stocks[$symbol]['currency'];
+                    $portfolioValue += fx_convert($this->pdo, $qty * $close, $currency, $base, $date);
+                }
+            }
+            $labels[] = $date;
+            $series[] = $portfolioValue;
+        }
+        return ['labels' => $labels, 'series' => $series];
+    }
+
+    /**
+     * @return array{labels:array<int,string>,series:array<int,float>}
+     */
+    public function positionValueSeries(int $userId, string $symbol, string $range = '6M'): array
+    {
+        $dates = $this->dateRangeFor($range);
+        $history = $this->indexHistory($this->priceDataService->getDailyHistory($symbol, $dates['start'], $dates['end']));
+        $trades = $this->loadTradesForSymbol($userId, $symbol, $dates['end']);
+        $currency = $this->lookupCurrency($symbol);
+        require_once __DIR__ . '/../fx.php';
+        $base = fx_user_main($this->pdo, $userId);
+        $qty = 0.0;
+        $series = [];
+        $labels = [];
+        foreach ($this->iterateDates($dates['start'], $dates['end']) as $date) {
+            if (isset($trades[$date])) {
+                foreach ($trades[$date] as $trade) {
+                    $qty += ($trade['side'] === 'buy') ? $trade['quantity'] : -$trade['quantity'];
+                }
+            }
+            $close = $history[$date]['close'] ?? null;
+            $labels[] = $date;
+            $series[] = ($close !== null) ? fx_convert($this->pdo, $qty * $close, $currency, $base, $date) : null;
+        }
+        return ['labels' => $labels, 'series' => $series];
+    }
+
+    private function dateRangeFor(string $range): array
+    {
+        $end = new DateTime();
+        $start = clone $end;
+        switch (strtoupper($range)) {
+            case '1D':
+                $start->sub(new DateInterval('P1D'));
+                break;
+            case '5D':
+                $start->sub(new DateInterval('P5D'));
+                break;
+            case '1M':
+                $start->sub(new DateInterval('P1M'));
+                break;
+            case '6M':
+                $start->sub(new DateInterval('P6M'));
+                break;
+            case '1Y':
+                $start->sub(new DateInterval('P1Y'));
+                break;
+            case '5Y':
+                $start->sub(new DateInterval('P5Y'));
+                break;
+            default:
+                $start->sub(new DateInterval('P1M'));
+        }
+        return ['start' => $start->format('Y-m-d'), 'end' => $end->format('Y-m-d')];
+    }
+
+    /**
+     * @return array<string,array<string,float|null>>
+     */
+    private function indexHistory(array $history): array
+    {
+        $indexed = [];
+        foreach ($history as $row) {
+            $indexed[$row['date']] = $row;
+        }
+        return $indexed;
+    }
+
+    /**
+     * @return array<string,int>
+     */
+    private function loadUserStocks(int $userId): array
+    {
+        $stmt = $this->pdo->prepare('SELECT DISTINCT s.symbol, s.id, s.currency FROM stock_trades t JOIN stocks s ON s.id = t.stock_id WHERE t.user_id=? ORDER BY s.symbol');
+        $stmt->execute([$userId]);
+        $result = [];
+        foreach ($stmt as $row) {
+            $result[$row['symbol']] = ['id' => (int)$row['id'], 'currency' => $row['currency'] ?? 'USD'];
+        }
+        return $result;
+    }
+
+    /**
+     * @return array<int,array{date:string,symbol:string,side:string,quantity:float}>
+     */
+    private function loadTrades(int $userId, string $endDate): array
+    {
+        $stmt = $this->pdo->prepare('SELECT executed_at::date AS trade_date, s.symbol, side, quantity FROM stock_trades t JOIN stocks s ON s.id = t.stock_id WHERE t.user_id=? AND executed_at::date <= ?::date ORDER BY executed_at ASC, t.id ASC');
+        $stmt->execute([$userId, $endDate]);
+        $rows = [];
+        foreach ($stmt as $row) {
+            $rows[] = [
+                'date' => $row['trade_date'],
+                'symbol' => $row['symbol'],
+                'side' => $row['side'],
+                'quantity' => (float)$row['quantity'],
+            ];
+        }
+        return $rows;
+    }
+
+    /**
+     * @return array<string,array<int,array{side:string,quantity:float}>> keyed by date
+     */
+    private function loadTradesForSymbol(int $userId, string $symbol, string $endDate): array
+    {
+        $stmt = $this->pdo->prepare('SELECT executed_at::date AS trade_date, side, quantity FROM stock_trades t JOIN stocks s ON s.id = t.stock_id WHERE t.user_id=? AND UPPER(s.symbol)=UPPER(?) AND executed_at::date <= ?::date ORDER BY executed_at ASC, t.id ASC');
+        $stmt->execute([$userId, $symbol, $endDate]);
+        $rows = [];
+        foreach ($stmt as $row) {
+            $date = $row['trade_date'];
+            if (!isset($rows[$date])) {
+                $rows[$date] = [];
+            }
+            $rows[$date][] = [
+                'side' => $row['side'],
+                'quantity' => (float)$row['quantity'],
+            ];
+        }
+        return $rows;
+    }
+
+    /**
+     * @return iterable<int,string>
+     */
+    private function iterateDates(string $start, string $end): iterable
+    {
+        $period = new DatePeriod(new DateTime($start), new DateInterval('P1D'), (new DateTime($end))->modify('+1 day'));
+        foreach ($period as $date) {
+            yield $date->format('Y-m-d');
+        }
+    }
+
+    private function lookupCurrency(string $symbol): string
+    {
+        $stmt = $this->pdo->prepare('SELECT currency FROM stocks WHERE UPPER(symbol)=UPPER(?) LIMIT 1');
+        $stmt->execute([$symbol]);
+        $currency = $stmt->fetchColumn();
+        return $currency ? (string)$currency : 'USD';
+    }
+}

--- a/src/stocks/PortfolioService.php
+++ b/src/stocks/PortfolioService.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Stocks;
+
+use DateInterval;
+use DateTime;
+use PDO;
+
+class PortfolioService
+{
+    private PDO $pdo;
+    private PriceDataService $priceDataService;
+
+    public function __construct(PDO $pdo, PriceDataService $priceDataService)
+    {
+        $this->pdo = $pdo;
+        $this->priceDataService = $priceDataService;
+    }
+
+    /**
+     * @param array{search?:?string,sector?:?string,currency?:?string,watchlist_only?:bool,realized_period?:?string} $filters
+     * @return array<string,mixed>
+     */
+    public function buildOverview(int $userId, array $filters = []): array
+    {
+        require_once __DIR__ . '/../fx.php';
+        $baseCurrency = fx_user_main($this->pdo, $userId) ?: 'EUR';
+        $today = (new DateTime())->format('Y-m-d');
+
+        $positions = $this->loadPositions($userId, $filters);
+        $symbols = array_map(static fn($row) => $row['symbol'], $positions);
+        $quotes = $this->priceDataService->getLiveQuotes($symbols);
+        $quotesBySymbol = [];
+        foreach ($quotes as $quote) {
+            $quotesBySymbol[$quote['symbol']] = $quote;
+        }
+
+        $holdings = [];
+        $totalMarketBase = 0.0;
+        $totalCostBase = 0.0;
+        $totalDailyBase = 0.0;
+        $cashImpactBase = 0.0;
+
+        foreach ($positions as $row) {
+            $symbol = $row['symbol'];
+            $currency = $row['currency'] ?: 'USD';
+            $qty = (float)$row['qty'];
+            $avgCost = (float)$row['avg_cost_ccy'];
+            $quote = $quotesBySymbol[$symbol] ?? null;
+            $last = $quote['last'] ?? null;
+            $prevClose = $quote['prev_close'] ?? null;
+            $marketValueCcy = $last !== null ? $qty * $last : $qty * $avgCost;
+            $marketValueBase = fx_convert($this->pdo, $marketValueCcy, $currency, $baseCurrency, $today);
+            $costCcy = $qty * $avgCost;
+            $costBase = fx_convert($this->pdo, $costCcy, $currency, $baseCurrency, $today);
+            $unrealizedCcy = $last !== null ? ($last - $avgCost) * $qty : 0.0;
+            $unrealizedBase = fx_convert($this->pdo, $unrealizedCcy, $currency, $baseCurrency, $today);
+            $dayPlCcy = ($last !== null && $prevClose !== null) ? ($last - $prevClose) * $qty : 0.0;
+            $dayPlBase = fx_convert($this->pdo, $dayPlCcy, $currency, $baseCurrency, $today);
+            $cashImpactBase += fx_convert($this->pdo, (float)$row['cash_impact_ccy'], $currency, $baseCurrency, $today);
+
+            $holdings[] = [
+                'symbol' => $symbol,
+                'name' => $row['name'] ?? $symbol,
+                'currency' => $currency,
+                'sector' => $row['sector'] ?? null,
+                'industry' => $row['industry'] ?? null,
+                'qty' => $qty,
+                'avg_cost' => $avgCost,
+                'last_price' => $last,
+                'prev_close' => $prevClose,
+                'market_value_ccy' => $marketValueCcy,
+                'market_value_base' => $marketValueBase,
+                'cost_ccy' => $costCcy,
+                'cost_base' => $costBase,
+                'unrealized_ccy' => $unrealizedCcy,
+                'unrealized_base' => $unrealizedBase,
+                'day_pl_ccy' => $dayPlCcy,
+                'day_pl_base' => $dayPlBase,
+                'stale' => $quote['stale'] ?? false,
+            ];
+            $totalMarketBase += $marketValueBase;
+            $totalCostBase += $costBase;
+            $totalDailyBase += $dayPlBase;
+        }
+
+        $weights = $this->distributeWeights($holdings, $totalMarketBase);
+        foreach ($holdings as $idx => $holding) {
+            $holdings[$idx]['weight_pct'] = $weights[$holding['symbol']] ?? 0.0;
+            $holdings[$idx]['risk_note'] = ($holdings[$idx]['weight_pct'] > 15) ? 'High concentration' : null;
+        }
+
+        $realizedPeriod = $filters['realized_period'] ?? 'YTD';
+        [$from, $to] = $this->resolvePeriodRange($realizedPeriod);
+        $realizedBase = $this->sumRealized($userId, $from, $to);
+
+        $overviewTotals = [
+            'base_currency' => $baseCurrency,
+            'total_market_value' => $totalMarketBase,
+            'total_cost' => $totalCostBase,
+            'unrealized_pl' => $totalMarketBase - $totalCostBase,
+            'unrealized_pct' => ($totalCostBase > 0) ? (($totalMarketBase - $totalCostBase) / $totalCostBase) * 100 : 0.0,
+            'daily_pl' => $totalDailyBase,
+            'cash_impact' => $cashImpactBase,
+            'realized_pl' => $realizedBase,
+            'realized_period' => $realizedPeriod,
+        ];
+
+        $allocations = $this->buildAllocations($holdings);
+        $watchlist = $this->buildWatchlist($userId, $baseCurrency, $today);
+
+        return [
+            'totals' => $overviewTotals,
+            'holdings' => $holdings,
+            'allocations' => $allocations,
+            'watchlist' => $watchlist,
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $filters
+     * @return array<int,array<string,mixed>>
+     */
+    private function loadPositions(int $userId, array $filters): array
+    {
+        $sql = 'SELECT sp.qty, sp.avg_cost_ccy, sp.avg_cost_currency, sp.cash_impact_ccy, s.symbol, s.name, s.currency, s.sector, s.industry
+            FROM stock_positions sp
+            JOIN stocks s ON s.id = sp.stock_id';
+        $params = [$userId];
+        if (!empty($filters['watchlist_only'])) {
+            $sql .= ' JOIN watchlist w ON w.stock_id = sp.stock_id AND w.user_id = sp.user_id';
+        }
+        $sql .= ' WHERE sp.user_id = ? AND sp.qty <> 0';
+        if (!empty($filters['sector'])) {
+            $sql .= ' AND s.sector = ?';
+            $params[] = $filters['sector'];
+        }
+        if (!empty($filters['currency'])) {
+            $sql .= ' AND s.currency = ?';
+            $params[] = strtoupper($filters['currency']);
+        }
+        if (!empty($filters['search'])) {
+            $sql .= ' AND (UPPER(s.symbol) LIKE ? OR UPPER(COALESCE(s.name, \'\')) LIKE ?)';
+            $needle = '%' . strtoupper($filters['search']) . '%';
+            $params[] = $needle;
+            $params[] = $needle;
+        }
+        $sql .= ' ORDER BY s.symbol ASC';
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $holdings
+     * @return array<string,float>
+     */
+    private function distributeWeights(array $holdings, float $totalMarket): array
+    {
+        $weights = [];
+        if ($totalMarket <= 0) {
+            foreach ($holdings as $holding) {
+                $weights[$holding['symbol']] = 0.0;
+            }
+            return $weights;
+        }
+        foreach ($holdings as $holding) {
+            $weights[$holding['symbol']] = ($holding['market_value_base'] / $totalMarket) * 100;
+        }
+        return $weights;
+    }
+
+    private function resolvePeriodRange(string $period): array
+    {
+        $now = new DateTime();
+        $end = clone $now;
+        $start = new DateTime($now->format('Y-01-01'));
+        switch (strtoupper($period)) {
+            case '1M':
+                $start = (clone $now)->sub(new DateInterval('P1M'));
+                break;
+            case '3M':
+                $start = (clone $now)->sub(new DateInterval('P3M'));
+                break;
+            case '1Y':
+                $start = (clone $now)->sub(new DateInterval('P1Y'));
+                break;
+            case 'ALL':
+                $start = new DateTime('2000-01-01');
+                break;
+            case 'YTD':
+            default:
+                break;
+        }
+        return [$start->format('Y-m-d'), $end->format('Y-m-d')];
+    }
+
+    private function sumRealized(int $userId, string $from, string $to): float
+    {
+        $stmt = $this->pdo->prepare('SELECT COALESCE(SUM(realized_pl_base),0) FROM stock_realized_pl WHERE user_id=? AND closed_at BETWEEN ?::timestamptz AND ?::timestamptz');
+        $stmt->execute([$userId, $from . ' 00:00:00', $to . ' 23:59:59']);
+        return (float)$stmt->fetchColumn();
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $holdings
+     * @return array<string,array<string,float>>
+     */
+    private function buildAllocations(array $holdings): array
+    {
+        $byTicker = [];
+        $bySector = [];
+        $byCurrency = [];
+        foreach ($holdings as $holding) {
+            $tickerShare = $holding['market_value_base'];
+            $symbol = $holding['symbol'];
+            $byTicker[$symbol] = ($byTicker[$symbol] ?? 0.0) + $tickerShare;
+            if (!empty($holding['sector'])) {
+                $bySector[$holding['sector']] = ($bySector[$holding['sector']] ?? 0.0) + $tickerShare;
+            }
+            if (!empty($holding['currency'])) {
+                $currency = $holding['currency'];
+                $byCurrency[$currency] = ($byCurrency[$currency] ?? 0.0) + $tickerShare;
+            }
+        }
+        $total = array_sum($byTicker);
+        $format = static function (array $data, float $total): array {
+            if ($total <= 0) {
+                return [];
+            }
+            $result = [];
+            foreach ($data as $label => $value) {
+                $result[] = [
+                    'label' => $label,
+                    'value' => $value,
+                    'weight_pct' => ($value / $total) * 100,
+                ];
+            }
+            usort($result, static fn($a, $b) => $b['value'] <=> $a['value']);
+            return $result;
+        };
+        return [
+            'by_ticker' => $format($byTicker, $total),
+            'by_sector' => $format($bySector, $total),
+            'by_currency' => $format($byCurrency, $total),
+        ];
+    }
+
+    private function buildWatchlist(int $userId, string $baseCurrency, string $today): array
+    {
+        $stmt = $this->pdo->prepare('SELECT w.stock_id, s.symbol, s.name, s.currency FROM watchlist w JOIN stocks s ON s.id = w.stock_id WHERE w.user_id=? ORDER BY s.symbol');
+        $stmt->execute([$userId]);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        if (!$rows) {
+            return [];
+        }
+        $symbols = array_map(static fn($row) => $row['symbol'], $rows);
+        $quotes = $this->priceDataService->getLiveQuotes($symbols);
+        $lookup = [];
+        foreach ($quotes as $quote) {
+            $lookup[$quote['symbol']] = $quote;
+        }
+        require_once __DIR__ . '/../fx.php';
+        $watchlist = [];
+        foreach ($rows as $row) {
+            $symbol = $row['symbol'];
+            $quote = $lookup[$symbol] ?? null;
+            $last = $quote['last'] ?? null;
+            $currency = $row['currency'] ?? 'USD';
+            $lastBase = $last !== null ? fx_convert($this->pdo, $last, $currency, $baseCurrency, $today) : null;
+            $watchlist[] = [
+                'symbol' => $symbol,
+                'name' => $row['name'] ?? $symbol,
+                'currency' => $currency,
+                'last_price' => $last,
+                'last_price_base' => $lastBase,
+                'prev_close' => $quote['prev_close'] ?? null,
+                'stale' => $quote['stale'] ?? false,
+            ];
+        }
+        return $watchlist;
+    }
+}

--- a/src/stocks/PortfolioService.php
+++ b/src/stocks/PortfolioService.php
@@ -231,6 +231,42 @@ class PortfolioService
         return $this->loadTransactions($userId);
     }
 
+    /**
+     * Collect the unique symbols referenced by the user's current positions and watchlist.
+     *
+     * @param array<string,mixed> $filters
+     * @return string[]
+     */
+    public function collectSymbols(int $userId, array $filters = []): array
+    {
+        $positions = $this->loadPositions($userId, $filters);
+        $watchlistRows = $this->loadWatchlistRows($userId);
+
+        $symbols = [];
+        foreach ($positions as $row) {
+            $symbol = strtoupper((string)($row['symbol'] ?? ''));
+            if ($symbol !== '') {
+                $symbols[] = $symbol;
+            }
+        }
+
+        foreach ($watchlistRows as $row) {
+            $symbol = strtoupper((string)($row['symbol'] ?? ''));
+            if ($symbol !== '') {
+                $symbols[] = $symbol;
+            }
+        }
+
+        if (empty($symbols)) {
+            return [];
+        }
+
+        $symbols = array_values(array_unique($symbols));
+        sort($symbols);
+
+        return $symbols;
+    }
+
     public function invalidateOverviewCache(int $userId): void
     {
         $prefix = $this->cacheKeyPrefix($userId);

--- a/src/stocks/PortfolioService.php
+++ b/src/stocks/PortfolioService.php
@@ -40,7 +40,7 @@ class PortfolioService
      * @param array{search?:?string,sector?:?string,currency?:?string,watchlist_only?:bool,realized_period?:?string} $filters
      * @return array<string,mixed>
      */
-    public function buildOverview(int $userId, array $filters = []): array
+    public function buildOverview(int $userId, array $filters = [], bool $includeTransactions = false): array
     {
         $baseCurrency = fx_user_main($this->pdo, $userId) ?: 'EUR';
         $today = (new DateTime())->format('Y-m-d');
@@ -154,7 +154,7 @@ class PortfolioService
 
         $allocations = $this->buildAllocations($holdings);
         $watchlist = $this->buildWatchlist($watchlistRows, $quotesBySymbol, $baseCurrency, $today);
-        $transactions = $this->loadTransactions($userId);
+        $transactions = $includeTransactions ? $this->loadTransactions($userId) : [];
 
         return [
             'totals' => $overviewTotals,
@@ -164,6 +164,16 @@ class PortfolioService
             'cash' => $cashEntries,
             'trades' => $transactions,
         ];
+    }
+
+    /**
+     * Expose transactions without forcing the overview snapshot to hydrate them every time.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function listTransactions(int $userId): array
+    {
+        return $this->loadTransactions($userId);
     }
 
     /**

--- a/src/stocks/PriceDataService.php
+++ b/src/stocks/PriceDataService.php
@@ -163,6 +163,21 @@ class PriceDataService
     }
 
     /**
+     * Force refresh quotes for the provided symbols and persist them to caches.
+     *
+     * @param string[] $symbols
+     * @return array<int, array{stock_id:int,symbol:string,last:?float,prev_close:?float,day_high:?float,day_low:?float,volume:?float,currency:?string,provider_ts:?string,stale:bool}>
+     */
+    public function refreshSymbols(array $symbols): array
+    {
+        if (empty($symbols)) {
+            return [];
+        }
+
+        return $this->getLiveQuotes($symbols, true);
+    }
+
+    /**
      * @return array<int, array{date:string,open:?float,high:?float,low:?float,close:?float,volume:?float}>
      */
     public function getDailyHistory(string $symbol, string $from, string $to): array

--- a/src/stocks/PriceDataService.php
+++ b/src/stocks/PriceDataService.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Stocks;
+
+use PDO;
+use Stocks\Adapters\NullPriceProvider;
+
+class PriceDataService
+{
+    private PDO $pdo;
+    private PriceProviderAdapter $adapter;
+    private int $ttlSeconds;
+    /** @var array<string, array> */
+    private array $memoryCache = [];
+
+    public function __construct(PDO $pdo, ?PriceProviderAdapter $adapter = null, int $ttlSeconds = 10)
+    {
+        $this->pdo = $pdo;
+        $this->adapter = $adapter ?? new NullPriceProvider();
+        $this->ttlSeconds = max(5, $ttlSeconds);
+    }
+
+    /**
+     * @param string[] $symbols
+     * @return array<int, array{stock_id:int,symbol:string,last:?float,prev_close:?float,day_high:?float,day_low:?float,volume:?float,currency:?string,provider_ts:?string,stale:bool}>
+     */
+    public function getLiveQuotes(array $symbols): array
+    {
+        if (empty($symbols)) {
+            return [];
+        }
+        $symbols = array_values(array_unique(array_map(static fn($s) => strtoupper(trim((string)$s)), $symbols)));
+        $placeholders = implode(',', array_fill(0, count($symbols), '?'));
+        $stmt = $this->pdo->prepare("SELECT id, UPPER(symbol) AS symbol, currency FROM stocks WHERE UPPER(symbol) IN ($placeholders)");
+        $stmt->execute($symbols);
+        $known = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        if (!$known) {
+            return [];
+        }
+        $now = time();
+        $result = [];
+        $toFetch = [];
+        $indexBySymbol = [];
+        $symbolCurrency = [];
+        foreach ($known as $row) {
+            $symbol = $row['symbol'];
+            $indexBySymbol[$symbol] = (int)$row['id'];
+            $symbolCurrency[$symbol] = $row['currency'] ?? null;
+            if (isset($this->memoryCache[$symbol])) {
+                $cached = $this->memoryCache[$symbol];
+                if (($cached['ts'] ?? 0) + $this->ttlSeconds > $now) {
+                    $result[] = $cached['data'];
+                    continue;
+                }
+            }
+            $toFetch[] = $symbol;
+        }
+
+        if (!empty($toFetch)) {
+            $placeholders = implode(',', array_fill(0, count($toFetch), '?'));
+            $ids = array_map(static fn($symbol) => $indexBySymbol[$symbol], $toFetch);
+            $lastRows = $this->pdo->prepare("SELECT stock_id,last,prev_close,day_high,day_low,volume,provider_ts,stale,updated_at FROM stock_prices_last WHERE stock_id IN ($placeholders)");
+            $lastRows->execute($ids);
+            $existing = [];
+            foreach ($lastRows as $row) {
+                $existing[(int)$row['stock_id']] = $row;
+            }
+
+            $needsProvider = [];
+            foreach ($toFetch as $symbol) {
+                $stockId = $indexBySymbol[$symbol];
+                $row = $existing[$stockId] ?? null;
+                if ($row) {
+                    $updatedAt = strtotime((string)$row['updated_at']);
+                    if ($updatedAt && $updatedAt + $this->ttlSeconds > $now) {
+                        $formatted = $this->formatRow($symbol, (int)$stockId, $row, $symbolCurrency[$symbol] ?? null);
+                        $result[] = $formatted;
+                        $this->memoryCache[$symbol] = ['ts' => $now, 'data' => $formatted];
+                        continue;
+                    }
+                }
+                $needsProvider[] = $symbol;
+            }
+
+            if (!empty($needsProvider)) {
+                $fetched = $this->adapter->fetchLiveQuotes($needsProvider);
+                foreach ($needsProvider as $symbol) {
+                    $stockId = $indexBySymbol[$symbol];
+                    $quote = $fetched[$symbol] ?? null;
+                    if ($quote) {
+                        $this->upsertLastQuote($stockId, $quote);
+                        $row = $quote + ['provider_ts' => $quote['provider_ts'] ?? null, 'stale' => false];
+                        $formatted = $this->formatRow($symbol, $stockId, $row, $symbolCurrency[$symbol] ?? null);
+                        $result[] = $formatted;
+                        $this->memoryCache[$symbol] = ['ts' => $now, 'data' => $formatted];
+                    } elseif (isset($existing[$stockId])) {
+                        $row = $existing[$stockId];
+                        $row['stale'] = true;
+                        $formatted = $this->formatRow($symbol, $stockId, $row, $symbolCurrency[$symbol] ?? null);
+                        $result[] = $formatted;
+                        $this->memoryCache[$symbol] = ['ts' => $now, 'data' => $formatted];
+                    }
+                }
+            }
+        }
+
+        return array_values($result);
+    }
+
+    /**
+     * @return array<int, array{date:string,open:?float,high:?float,low:?float,close:?float,volume:?float}>
+     */
+    public function getDailyHistory(string $symbol, string $from, string $to): array
+    {
+        $symbol = strtoupper(trim($symbol));
+        if ($symbol === '') {
+            return [];
+        }
+        $stockId = $this->lookupStockId($symbol);
+        if (!$stockId) {
+            return [];
+        }
+        $stmt = $this->pdo->prepare('SELECT date, open, high, low, close, volume FROM price_daily WHERE stock_id=? AND date BETWEEN ?::date AND ?::date ORDER BY date ASC');
+        $stmt->execute([$stockId, $from, $to]);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        if (!$this->coversRange($rows, $from, $to)) {
+            $candles = $this->adapter->fetchDailyHistory($symbol, $from, $to);
+            foreach ($candles as $candle) {
+                $this->storeDailyCandle($stockId, $candle);
+            }
+            $stmt->execute([$stockId, $from, $to]);
+            $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        }
+        return array_map(static function ($row) {
+            return [
+                'date' => $row['date'],
+                'open' => $row['open'] !== null ? (float)$row['open'] : null,
+                'high' => $row['high'] !== null ? (float)$row['high'] : null,
+                'low' => $row['low'] !== null ? (float)$row['low'] : null,
+                'close' => $row['close'] !== null ? (float)$row['close'] : null,
+                'volume' => $row['volume'] !== null ? (float)$row['volume'] : null,
+            ];
+        }, $rows);
+    }
+
+    public function refreshMetadata(string $symbol): array
+    {
+        $symbol = strtoupper(trim($symbol));
+        if ($symbol === '') {
+            return [];
+        }
+        $stockId = $this->lookupStockId($symbol);
+        if (!$stockId) {
+            return [];
+        }
+        $meta = $this->adapter->lookupMetadata($symbol);
+        if (!$meta) {
+            return [];
+        }
+        $columns = [];
+        $params = [];
+        foreach (['name', 'exchange', 'currency', 'sector', 'industry', 'beta'] as $field) {
+            if (array_key_exists($field, $meta)) {
+                $columns[] = $field . ' = ?';
+                $params[] = $meta[$field];
+            }
+        }
+        if ($columns) {
+            $params[] = $stockId;
+            $sql = 'UPDATE stocks SET ' . implode(', ', $columns) . ', updated_at = NOW() WHERE id = ?';
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute($params);
+        }
+        return $meta;
+    }
+
+    private function lookupStockId(string $symbol): ?int
+    {
+        $stmt = $this->pdo->prepare('SELECT id FROM stocks WHERE UPPER(symbol)=? LIMIT 1');
+        $stmt->execute([$symbol]);
+        $id = $stmt->fetchColumn();
+        return $id ? (int)$id : null;
+    }
+
+    /**
+     * @param array{last:?float,prev_close:?float,high:?float,low:?float,volume:?float,provider_ts:?string,currency?:?string} $quote
+     */
+    private function upsertLastQuote(int $stockId, array $quote): void
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO stock_prices_last(stock_id,last,prev_close,day_high,day_low,volume,provider_ts,stale,updated_at)
+            VALUES(?,?,?,?,?,?,?,FALSE,NOW())
+            ON CONFLICT (stock_id) DO UPDATE SET
+                last = EXCLUDED.last,
+                prev_close = EXCLUDED.prev_close,
+                day_high = EXCLUDED.day_high,
+                day_low = EXCLUDED.day_low,
+                volume = EXCLUDED.volume,
+                provider_ts = EXCLUDED.provider_ts,
+                stale = FALSE,
+                updated_at = NOW()');
+        $stmt->execute([
+            $stockId,
+            $quote['last'] ?? null,
+            $quote['prev_close'] ?? null,
+            $quote['high'] ?? null,
+            $quote['low'] ?? null,
+            $quote['volume'] ?? null,
+            $quote['provider_ts'] ?? null,
+        ]);
+    }
+
+    /**
+     * @param array $row
+     * @return array{stock_id:int,symbol:string,last:?float,prev_close:?float,day_high:?float,day_low:?float,volume:?float,currency:?string,provider_ts:?string,stale:bool}
+     */
+    private function formatRow(string $symbol, int $stockId, array $row, ?string $fallbackCurrency = null): array
+    {
+        return [
+            'stock_id' => $stockId,
+            'symbol' => $symbol,
+            'last' => isset($row['last']) ? (float)$row['last'] : null,
+            'prev_close' => isset($row['prev_close']) ? (float)$row['prev_close'] : null,
+            'day_high' => isset($row['day_high']) ? (float)$row['day_high'] : null,
+            'day_low' => isset($row['day_low']) ? (float)$row['day_low'] : null,
+            'volume' => isset($row['volume']) ? (float)$row['volume'] : null,
+            'currency' => $row['currency'] ?? $fallbackCurrency,
+            'provider_ts' => $row['provider_ts'] ?? null,
+            'stale' => (bool)($row['stale'] ?? false),
+        ];
+    }
+
+    /**
+     * @param array<int, array{date:string}> $rows
+     */
+    private function coversRange(array $rows, string $from, string $to): bool
+    {
+        if (!$rows) {
+            return false;
+        }
+        $first = $rows[0]['date'] ?? null;
+        $last = $rows[count($rows) - 1]['date'] ?? null;
+        if (!$first || !$last) {
+            return false;
+        }
+        return ($first <= $from) && ($last >= $to);
+    }
+
+    /**
+     * @param array{date:string,open:?float,high:?float,low:?float,close:?float,volume:?float} $candle
+     */
+    private function storeDailyCandle(int $stockId, array $candle): void
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO price_daily(stock_id,date,open,high,low,close,volume,provider,created_at)
+            VALUES(?,?,?,?,?,?,?,\'provider\',NOW())
+            ON CONFLICT (stock_id,date) DO UPDATE SET open=EXCLUDED.open, high=EXCLUDED.high, low=EXCLUDED.low, close=EXCLUDED.close, volume=EXCLUDED.volume');
+        $stmt->execute([
+            $stockId,
+            $candle['date'],
+            $candle['open'] ?? null,
+            $candle['high'] ?? null,
+            $candle['low'] ?? null,
+            $candle['close'] ?? null,
+            $candle['volume'] ?? null,
+        ]);
+    }
+}

--- a/src/stocks/PriceProviderAdapter.php
+++ b/src/stocks/PriceProviderAdapter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Stocks;
+
+interface PriceProviderAdapter
+{
+    /**
+     * @param string[] $symbols
+     * @return array<string, array{last: ?float, prev_close: ?float, high: ?float, low: ?float, volume: ?float, currency: ?string, provider_ts: ?string}>
+     */
+    public function fetchLiveQuotes(array $symbols): array;
+
+    /**
+     * @param string $symbol
+     * @param string $from  ISO date (YYYY-MM-DD)
+     * @param string $to    ISO date (YYYY-MM-DD)
+     * @return array<int, array{date: string, open: ?float, high: ?float, low: ?float, close: ?float, volume: ?float}>
+     */
+    public function fetchDailyHistory(string $symbol, string $from, string $to): array;
+
+    /**
+     * Metadata lookup. Returns array with keys: name, exchange, currency, sector, industry, beta
+     *
+     * @return array{name?: string, exchange?: string, currency?: string, sector?: string, industry?: string, beta?: ?float}
+     */
+    public function lookupMetadata(string $symbol): array;
+}

--- a/src/stocks/SignalsService.php
+++ b/src/stocks/SignalsService.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Stocks;
+
+use DateTime;
+use PDO;
+
+class SignalsService
+{
+    private PDO $pdo;
+    private PriceDataService $priceDataService;
+
+    public function __construct(PDO $pdo, PriceDataService $priceDataService)
+    {
+        $this->pdo = $pdo;
+        $this->priceDataService = $priceDataService;
+    }
+
+    /**
+     * @param array{symbol:string,currency:string,avg_cost:float,qty:float,last_price:?float,weight_pct:float} $holding
+     * @param array{prev_close:?float} $quote
+     * @param array<string,float> $portfolioTotals expects keys target_allocation? etc.
+     * @return array{signals:array<int,array{label:string,value:string}>,suggestions:array<int,string>}
+     */
+    public function analyze(int $userId, array $holding, array $quote, array $portfolioTotals = []): array
+    {
+        $symbol = $holding['symbol'];
+        $history = $this->priceDataService->getDailyHistory($symbol, (new DateTime('-180 days'))->format('Y-m-d'), (new DateTime())->format('Y-m-d'));
+        $closes = array_map(static fn($candle) => $candle['close'], $history);
+        $signals = [];
+
+        $sma20 = $this->simpleMovingAverage($closes, 20);
+        $sma50 = $this->simpleMovingAverage($closes, 50);
+        $last = $holding['last_price'];
+        if ($sma20 !== null) {
+            $signals[] = [
+                'label' => '20D SMA',
+                'value' => sprintf('%0.2f (%s)', $sma20, $last !== null ? ($last >= $sma20 ? 'above' : 'below') : 'n/a'),
+            ];
+        }
+        if ($sma50 !== null) {
+            $signals[] = [
+                'label' => '50D SMA',
+                'value' => sprintf('%0.2f (%s)', $sma50, $last !== null ? ($last >= $sma50 ? 'above' : 'below') : 'n/a'),
+            ];
+        }
+
+        $rsi = $this->computeRsi($closes, 14);
+        if ($rsi !== null) {
+            $signals[] = [
+                'label' => 'RSI(14)',
+                'value' => sprintf('%0.1f', $rsi),
+            ];
+        }
+
+        $gap = null;
+        if ($last !== null && !empty($quote['prev_close'])) {
+            $gap = $quote['prev_close'] != 0.0 ? (($last - $quote['prev_close']) / $quote['prev_close']) * 100 : null;
+            if ($gap !== null) {
+                $signals[] = [
+                    'label' => 'Gap vs Prev Close',
+                    'value' => sprintf('%+.2f%%', $gap),
+                ];
+            }
+        }
+
+        $positionHealth = $this->positionHealth($holding, $closes);
+        if ($positionHealth) {
+            $signals[] = [
+                'label' => 'Position Health',
+                'value' => $positionHealth,
+            ];
+        }
+
+        $suggestions = $this->buildSuggestions($holding, $sma50, $rsi, $gap, $portfolioTotals);
+
+        return [
+            'signals' => $signals,
+            'suggestions' => $suggestions,
+        ];
+    }
+
+    private function simpleMovingAverage(array $values, int $period): ?float
+    {
+        if (count($values) < $period) {
+            return null;
+        }
+        $slice = array_slice($values, -$period);
+        $slice = array_filter($slice, static fn($v) => $v !== null);
+        if (count($slice) < $period / 2) {
+            return null;
+        }
+        return array_sum($slice) / count($slice);
+    }
+
+    private function computeRsi(array $closes, int $period): ?float
+    {
+        if (count($closes) <= $period) {
+            return null;
+        }
+        $gains = 0.0;
+        $losses = 0.0;
+        for ($i = count($closes) - $period; $i < count($closes); $i++) {
+            if (!isset($closes[$i - 1]) || $closes[$i] === null || $closes[$i - 1] === null) {
+                continue;
+            }
+            $change = $closes[$i] - $closes[$i - 1];
+            if ($change >= 0) {
+                $gains += $change;
+            } else {
+                $losses += abs($change);
+            }
+        }
+        $avgGain = $gains / $period;
+        $avgLoss = $losses / $period;
+        if ($avgLoss == 0.0) {
+            return 100.0;
+        }
+        $rs = $avgGain / $avgLoss;
+        return 100 - (100 / (1 + $rs));
+    }
+
+    private function positionHealth(array $holding, array $closes): ?string
+    {
+        if (empty($closes) || $holding['last_price'] === null) {
+            return null;
+        }
+        $last = $holding['last_price'];
+        $avgCost = $holding['avg_cost'];
+        $diff = $avgCost > 0 ? (($last - $avgCost) / $avgCost) * 100 : null;
+        $valid = array_filter($closes, static fn($v) => $v !== null);
+        if (empty($valid)) {
+            return $parts ? implode(' · ', $parts) : null;
+        }
+        $peak = max($valid);
+        $drawdown = $peak > 0 ? (($last - $peak) / $peak) * 100 : null;
+        $parts = [];
+        if ($diff !== null) {
+            $parts[] = sprintf('%.2f%% vs avg cost', $diff);
+        }
+        if ($drawdown !== null) {
+            $parts[] = sprintf('%.2f%% from 6M peak', $drawdown);
+        }
+        return $parts ? implode(' · ', $parts) : null;
+    }
+
+    /**
+     * @param array<string,mixed> $portfolioTotals
+     * @return string[]
+     */
+    private function buildSuggestions(array $holding, ?float $sma50, ?float $rsi, ?float $gap, array $portfolioTotals): array
+    {
+        $suggestions = [];
+        $last = $holding['last_price'];
+        $weight = $holding['weight_pct'] ?? 0.0;
+        $target = $this->targetAllocation($holding['symbol'], $portfolioTotals);
+
+        if ($last !== null && $sma50 !== null && $last > $sma50 && $weight < $target) {
+            $suggestions[] = sprintf('Potential add — price %.2f above 50D SMA %.2f, weight %.1f%% vs target %.1f%%', $last, $sma50, $weight, $target);
+        }
+        if (($weight > $target && $weight > 0) || ($rsi !== null && $rsi > 70)) {
+            $reason = $weight > $target ? sprintf('weight %.1f%% > target %.1f%%', $weight, $target) : sprintf('RSI %.1f > 70', $rsi);
+            $suggestions[] = 'Trim — ' . $reason;
+        }
+        if ($gap !== null && abs($gap) > 3) {
+            $suggestions[] = sprintf('Consider stop update — gap %+.2f%% today', $gap);
+        }
+        if ($rsi !== null && $rsi > 40 && $rsi < 60 && $sma50 !== null && $last !== null && abs($last - $sma50) / $sma50 < 0.02) {
+            $suggestions[] = 'Watch only — momentum mixed and RSI neutral';
+        }
+        if ($weight > 15) {
+            $suggestions[] = sprintf('Concentration warning — %.1f%% of portfolio', $weight);
+        }
+        return array_values(array_unique($suggestions));
+    }
+
+    /**
+     * @param array<string,mixed> $portfolioTotals
+     */
+    private function targetAllocation(string $symbol, array $portfolioTotals): float
+    {
+        $targets = $this->loadTargetAllocations((int)($portfolioTotals['user_id'] ?? 0));
+        if (isset($targets[$symbol])) {
+            return (float)$targets[$symbol];
+        }
+        return isset($portfolioTotals['default_target']) ? (float)$portfolioTotals['default_target'] : 10.0;
+    }
+
+    /**
+     * @return array<string,float>
+     */
+    private function loadTargetAllocations(int $userId): array
+    {
+        if ($userId <= 0) {
+            return [];
+        }
+        $stmt = $this->pdo->prepare('SELECT target_allocations FROM user_settings_stocks WHERE user_id=?');
+        $stmt->execute([$userId]);
+        $json = $stmt->fetchColumn();
+        if (!$json) {
+            return [];
+        }
+        $decoded = json_decode((string)$json, true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+        $clean = [];
+        foreach ($decoded as $key => $value) {
+            $clean[strtoupper($key)] = (float)$value;
+        }
+        return $clean;
+    }
+}

--- a/src/stocks/TradeService.php
+++ b/src/stocks/TradeService.php
@@ -115,7 +115,8 @@ class TradeService
     {
         if (strtoupper($side) === 'SELL') {
             $available = $this->legacyAvailableQuantity($userId, $symbol);
-            if ($quantity - $available > 1e-6) {
+            $tolerance = max(1e-6, abs($available) * 1e-6);
+            if ($quantity > $available + $tolerance) {
                 throw new RuntimeException('Sell quantity exceeds available lots for ' . $symbol);
             }
         }
@@ -448,6 +449,7 @@ class TradeService
     {
         $stmt = $this->pdo->prepare("SELECT COALESCE(SUM(CASE WHEN LOWER(side) = 'buy' THEN quantity ELSE -quantity END), 0) FROM stock_trades WHERE user_id=? AND UPPER(symbol)=?");
         $stmt->execute([$userId, $symbol]);
-        return (float)$stmt->fetchColumn();
+        $available = (float)$stmt->fetchColumn();
+        return round($available, 6);
     }
 }

--- a/src/stocks/TradeService.php
+++ b/src/stocks/TradeService.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Stocks;
+
+use DateTime;
+use PDO;
+use PDOException;
+use RuntimeException;
+
+class TradeService
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * @param array{symbol:string,market?:?string,quantity:float,price:float,fee?:float,side:string,currency:string,executed_at?:?string,note?:?string} $payload
+     */
+    public function recordTrade(int $userId, array $payload): int
+    {
+        $symbol = strtoupper(trim($payload['symbol'] ?? ''));
+        if ($symbol === '') {
+            throw new RuntimeException('Symbol is required');
+        }
+        $side = strtoupper(trim($payload['side'] ?? ''));
+        if (!in_array($side, ['BUY', 'SELL'], true)) {
+            throw new RuntimeException('Invalid trade side');
+        }
+        $quantity = (float)($payload['quantity'] ?? 0);
+        if ($quantity <= 0) {
+            throw new RuntimeException('Quantity must be positive');
+        }
+        $price = (float)($payload['price'] ?? 0);
+        if ($price <= 0) {
+            throw new RuntimeException('Price must be positive');
+        }
+        $fee = isset($payload['fee']) ? (float)$payload['fee'] : 0.0;
+        $currency = strtoupper(trim($payload['currency'] ?? 'USD'));
+        $executedAt = $payload['executed_at'] ?? null;
+        $executedTs = $executedAt ? new DateTime($executedAt) : new DateTime();
+        $note = $payload['note'] ?? null;
+        $market = isset($payload['market']) && $payload['market'] !== null && $payload['market'] !== ''
+            ? strtoupper((string)$payload['market'])
+            : null;
+
+        $stockId = $this->ensureStockExists($symbol, $market, $currency);
+
+        $this->pdo->beginTransaction();
+        try {
+            $stmt = $this->pdo->prepare('INSERT INTO stock_trades(user_id, stock_id, symbol, trade_on, side, quantity, price, currency, executed_at, fee, note, market, created_at, updated_at)
+                VALUES(?,?,?,?,?,?,?,?,?,?,?, ?, NOW(), NOW()) RETURNING id');
+            $stmt->execute([
+                $userId,
+                $stockId,
+                $symbol,
+                $executedTs->format('Y-m-d'),
+                strtolower($side),
+                $quantity,
+                $price,
+                $currency,
+                $executedTs->format('Y-m-d H:i:sP'),
+                $fee,
+                $note,
+                $market,
+            ]);
+            $tradeId = (int)$stmt->fetchColumn();
+
+            $this->rebuildPositions($userId, $stockId);
+            $this->pdo->commit();
+            return $tradeId;
+        } catch (PDOException $e) {
+            $this->pdo->rollBack();
+            throw $e;
+        }
+    }
+
+    public function deleteTrade(int $userId, int $tradeId): void
+    {
+        $trade = $this->fetchTrade($userId, $tradeId);
+        if (!$trade) {
+            return;
+        }
+        $stockId = (int)$trade['stock_id'];
+        $this->pdo->beginTransaction();
+        try {
+            $this->pdo->prepare('DELETE FROM stock_trades WHERE id=? AND user_id=?')->execute([$tradeId, $userId]);
+            $this->rebuildPositions($userId, $stockId);
+            $this->pdo->commit();
+        } catch (PDOException $e) {
+            $this->pdo->rollBack();
+            throw $e;
+        }
+    }
+
+    public function rebuildPositions(int $userId, ?int $stockId = null): void
+    {
+        $stocks = $stockId ? [ (int)$stockId ] : $this->loadUserStockIds($userId);
+        if (empty($stocks)) {
+            return;
+        }
+        require_once __DIR__ . '/../fx.php';
+        $baseCurrency = fx_user_main($this->pdo, $userId);
+
+        foreach ($stocks as $sid) {
+            $positionId = $this->ensurePositionRow($userId, $sid);
+            $this->pdo->prepare('DELETE FROM stock_lots WHERE position_id=?')->execute([$positionId]);
+            $this->pdo->prepare('DELETE FROM stock_realized_pl WHERE user_id=? AND stock_id=?')->execute([$userId, $sid]);
+            $this->pdo->prepare('UPDATE stock_positions SET qty=0, avg_cost_ccy=0, cash_impact_ccy=0, updated_at=NOW() WHERE id=?')->execute([$positionId]);
+
+            $stmt = $this->pdo->prepare('SELECT id, side, quantity, price, fee, currency, executed_at FROM stock_trades WHERE user_id=? AND stock_id=? ORDER BY executed_at ASC, id ASC');
+            $stmt->execute([$userId, $sid]);
+            $trades = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            if (!$trades) {
+                continue;
+            }
+
+            $qty = 0.0;
+            $totalCost = 0.0;
+            $cashImpact = 0.0;
+            $lots = [];
+
+            foreach ($trades as $trade) {
+                $tradeQty = (float)$trade['quantity'];
+                $tradePrice = (float)$trade['price'];
+                $tradeFee = (float)($trade['fee'] ?? 0);
+                $executedAt = new DateTime($trade['executed_at']);
+                $currency = $trade['currency'] ?: 'USD';
+                if ($trade['side'] === 'buy') {
+                    $cost = $tradeQty * $tradePrice + $tradeFee;
+                    $qty += $tradeQty;
+                    $totalCost += $cost;
+                    $cashImpact -= $cost;
+                    $lotId = $this->insertLot($positionId, $tradeQty, $tradePrice, $tradeFee, $executedAt);
+                    $lots[] = [
+                        'id' => $lotId,
+                        'qty_total' => $tradeQty,
+                        'remaining' => $tradeQty,
+                        'price' => $tradePrice,
+                        'fee' => $tradeFee,
+                        'opened_at' => $executedAt,
+                    ];
+                } else {
+                    if ($tradeQty <= 0) {
+                        continue;
+                    }
+                    if ($tradeQty > $qty + 1e-8) {
+                        throw new RuntimeException('Sell quantity exceeds available lots for ' . $sid);
+                    }
+                    $sellFeePerShare = $tradeFee > 0 ? $tradeFee / $tradeQty : 0.0;
+                    $remaining = $tradeQty;
+                    $realizedCcy = 0.0;
+                    foreach ($lots as &$lot) {
+                        if ($remaining <= 0) {
+                            break;
+                        }
+                        if ($lot['remaining'] <= 0) {
+                            continue;
+                        }
+                        $portion = min($lot['remaining'], $remaining);
+                        $buyFeePerShare = $lot['fee'] > 0 && $lot['qty_total'] > 0 ? $lot['fee'] / $lot['qty_total'] : 0.0;
+                        $costPerShare = $lot['price'] + $buyFeePerShare;
+                        $proceedsPerShare = $tradePrice - $sellFeePerShare;
+                        $realizedCcy += ($proceedsPerShare - $costPerShare) * $portion;
+                        $lot['remaining'] -= $portion;
+                        $qty -= $portion;
+                        $totalCost -= $costPerShare * $portion;
+                        $this->updateLot($lot['id'], $lot['remaining'], $lot['qty_total'] - $lot['remaining'], $executedAt, $lot['remaining'] <= 1e-8);
+                        $remaining -= $portion;
+                    }
+                    unset($lot);
+                    if ($remaining > 1e-6) {
+                        throw new RuntimeException('Insufficient lot quantity when processing sell trade');
+                    }
+                    $cashImpact += $tradeQty * $tradePrice - $tradeFee;
+                    $realizedBase = fx_convert($this->pdo, $realizedCcy, $currency, $baseCurrency, $executedAt->format('Y-m-d'));
+                    $this->insertRealized($userId, $sid, (int)$trade['id'], $realizedBase, $realizedCcy, $currency, $tradeQty, $executedAt);
+                }
+            }
+
+            $avgCost = ($qty > 0) ? $totalCost / $qty : 0.0;
+            $this->pdo->prepare('UPDATE stock_positions SET qty=?, avg_cost_ccy=?, avg_cost_currency=(SELECT currency FROM stocks WHERE id=?), cash_impact_ccy=?, updated_at=NOW() WHERE id=?')
+                ->execute([$qty, $avgCost, $sid, $cashImpact, $positionId]);
+        }
+    }
+
+    private function ensureStockExists(string $symbol, ?string $market, string $currency): int
+    {
+        $stmt = $this->pdo->prepare('SELECT id FROM stocks WHERE UPPER(symbol)=? LIMIT 1');
+        $stmt->execute([$symbol]);
+        $id = $stmt->fetchColumn();
+        if ($id) {
+            $this->pdo->prepare('UPDATE stocks SET market=COALESCE(?, market), currency=COALESCE(?, currency), updated_at=NOW() WHERE id=?')
+                ->execute([$market, $currency, $id]);
+            return (int)$id;
+        }
+        $stmt = $this->pdo->prepare('INSERT INTO stocks(symbol, market, currency, created_at, updated_at) VALUES(UPPER(?), ?, ?, NOW(), NOW()) RETURNING id');
+        $stmt->execute([$symbol, $market, $currency]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    private function ensurePositionRow(int $userId, int $stockId): int
+    {
+        $stmt = $this->pdo->prepare('SELECT id FROM stock_positions WHERE user_id=? AND stock_id=?');
+        $stmt->execute([$userId, $stockId]);
+        $id = $stmt->fetchColumn();
+        if ($id) {
+            return (int)$id;
+        }
+        $stmt = $this->pdo->prepare('INSERT INTO stock_positions(user_id, stock_id, avg_cost_currency) VALUES(?,?, (SELECT currency FROM stocks WHERE id=?)) RETURNING id');
+        $stmt->execute([$userId, $stockId, $stockId]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    private function fetchTrade(int $userId, int $tradeId): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM stock_trades WHERE id=? AND user_id=?');
+        $stmt->execute([$tradeId, $userId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
+
+    private function insertLot(int $positionId, float $qty, float $price, float $fee, DateTime $openedAt): int
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO stock_lots(position_id, qty_open, qty_closed, open_price, fee, opened_at, created_at, updated_at)
+            VALUES(?,?,?,?,?,?, NOW(), NOW()) RETURNING id');
+        $stmt->execute([$positionId, $qty, 0, $price, $fee, $openedAt->format('Y-m-d H:i:sP')]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    private function updateLot(int $lotId, float $qtyOpen, float $qtyClosed, DateTime $closedAt, bool $closed): void
+    {
+        $this->pdo->prepare('UPDATE stock_lots SET qty_open=?, qty_closed=?, closed_at=?, updated_at=NOW() WHERE id=?')
+            ->execute([$qtyOpen, $qtyClosed, $closed ? $closedAt->format('Y-m-d H:i:sP') : null, $lotId]);
+    }
+
+    private function insertRealized(int $userId, int $stockId, int $tradeId, float $base, float $ccy, string $currency, float $qty, DateTime $closedAt): void
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO stock_realized_pl(user_id, stock_id, sell_trade_id, realized_pl_base, realized_pl_ccy, currency, method, qty_closed, closed_at, created_at)
+            VALUES(?,?,?,?,?,?,?,?,?, NOW())');
+        $stmt->execute([$userId, $stockId, $tradeId, $base, $ccy, $currency, 'FIFO', $qty, $closedAt->format('Y-m-d H:i:sP')]);
+    }
+
+    /**
+     * @return int[]
+     */
+    private function loadUserStockIds(int $userId): array
+    {
+        $stmt = $this->pdo->prepare('SELECT DISTINCT stock_id FROM stock_trades WHERE user_id=?');
+        $stmt->execute([$userId]);
+        return array_map('intval', $stmt->fetchAll(PDO::FETCH_COLUMN));
+    }
+}

--- a/src/stocks/TradeService.php
+++ b/src/stocks/TradeService.php
@@ -188,6 +188,11 @@ class TradeService
 
     private function ensureStockExists(string $symbol, ?string $market, string $currency): int
     {
+        if ($market !== null && $market !== '') {
+            $market = strtoupper($market);
+        } else {
+            $market = null;
+        }
         $stmt = $this->pdo->prepare('SELECT id FROM stocks WHERE UPPER(symbol)=? LIMIT 1');
         $stmt->execute([$symbol]);
         $id = $stmt->fetchColumn();
@@ -196,8 +201,9 @@ class TradeService
                 ->execute([$market, $currency, $id]);
             return (int)$id;
         }
+        $insertMarket = $market ?: 'NASDAQ';
         $stmt = $this->pdo->prepare('INSERT INTO stocks(symbol, market, currency, created_at, updated_at) VALUES(UPPER(?), ?, ?, NOW(), NOW()) RETURNING id');
-        $stmt->execute([$symbol, $market, $currency]);
+        $stmt->execute([$symbol, $insertMarket, $currency]);
         return (int)$stmt->fetchColumn();
     }
 

--- a/tests/stocks/trade_service_test.php
+++ b/tests/stocks/trade_service_test.php
@@ -1,0 +1,109 @@
+<?php
+require __DIR__ . '/../../config/load_env.php';
+$config = require __DIR__ . '/../../config/config.php';
+try {
+    $dsn = sprintf('pgsql:host=%s;port=%s;dbname=%s', $config['db']['host'], $config['db']['port'], $config['db']['name']);
+    $pdo = new PDO($dsn, $config['db']['user'], $config['db']['pass'], [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ]);
+} catch (PDOException $e) {
+    fwrite(STDERR, "Skipping tests: database unavailable ({$e->getMessage()})\n");
+    exit(0);
+}
+require __DIR__ . '/../../src/fx.php';
+require __DIR__ . '/../../src/stocks/PriceProviderAdapter.php';
+require __DIR__ . '/../../src/stocks/Adapters/NullPriceProvider.php';
+require __DIR__ . '/../../src/stocks/PriceDataService.php';
+require __DIR__ . '/../../src/stocks/TradeService.php';
+require __DIR__ . '/../../src/stocks/SignalsService.php';
+
+use Stocks\Adapters\NullPriceProvider;
+use Stocks\PriceDataService;
+use Stocks\SignalsService;
+use Stocks\TradeService;
+
+function assert_close($expected, $actual, $delta = 0.01, $message = '') {
+    if (abs($expected - $actual) > $delta) {
+        throw new RuntimeException($message . ' expected ' . $expected . ' got ' . $actual);
+    }
+}
+
+try {
+    $pdo->beginTransaction();
+
+    $pdo->exec("INSERT INTO users(email, password_hash, full_name) VALUES('stocks_test@example.com','x','Test User')");
+    $userId = (int)$pdo->lastInsertId();
+    $pdo->prepare('INSERT INTO user_currencies(user_id, code, is_main) VALUES(?,?,true)')->execute([$userId, 'USD']);
+
+    $tradeService = new TradeService($pdo);
+
+    $tradeService->recordTrade($userId, [
+        'symbol' => 'TEST',
+        'side' => 'BUY',
+        'quantity' => 10,
+        'price' => 100,
+        'currency' => 'USD',
+        'fee' => 0.5,
+        'executed_at' => '2023-01-02 15:30:00'
+    ]);
+    $tradeService->recordTrade($userId, [
+        'symbol' => 'TEST',
+        'side' => 'BUY',
+        'quantity' => 5,
+        'price' => 110,
+        'currency' => 'USD',
+        'fee' => 0.5,
+        'executed_at' => '2023-01-15 15:30:00'
+    ]);
+    $tradeService->recordTrade($userId, [
+        'symbol' => 'TEST',
+        'side' => 'SELL',
+        'quantity' => 8,
+        'price' => 150,
+        'currency' => 'USD',
+        'fee' => 0.5,
+        'executed_at' => '2023-02-10 15:30:00'
+    ]);
+
+    $pos = $pdo->query("SELECT qty, avg_cost_ccy FROM stock_positions sp JOIN stocks s ON s.id=sp.stock_id WHERE sp.user_id={$userId} AND s.symbol='TEST'")->fetch(PDO::FETCH_ASSOC);
+    assert_close(7.0, (float)$pos['qty'], 0.0001, 'Position quantity mismatch');
+    assert_close(107.14, (float)$pos['avg_cost_ccy'], 0.1, 'Average cost mismatch');
+
+    $realized = $pdo->query("SELECT realized_pl_ccy FROM stock_realized_pl WHERE user_id={$userId} AND stock_id=(SELECT id FROM stocks WHERE symbol='TEST')")->fetchColumn();
+    assert_close(399.5, (float)$realized, 0.5, 'Realized P/L mismatch');
+
+    $pdo->exec("DELETE FROM price_daily");
+    $stockId = $pdo->query("SELECT id FROM stocks WHERE symbol='TEST'")->fetchColumn();
+    $insert = $pdo->prepare('INSERT INTO price_daily(stock_id, date, open, high, low, close, volume) VALUES(?,?,?,?,?,?,?) ON CONFLICT(stock_id,date) DO UPDATE SET close=excluded.close');
+    $start = new DateTime('2023-01-01');
+    for ($i=0; $i<60; $i++) {
+        $date = (clone $start)->modify("+$i days")->format('Y-m-d');
+        $price = 100 + $i * 0.5;
+        $insert->execute([$stockId, $date, $price, $price + 1, $price - 1, $price, 1000000]);
+    }
+
+    $priceService = new PriceDataService($pdo, new NullPriceProvider(), 10);
+    $signals = new SignalsService($pdo, $priceService);
+    $holding = [
+        'symbol' => 'TEST',
+        'currency' => 'USD',
+        'avg_cost' => 100,
+        'qty' => 1,
+        'last_price' => 130,
+        'prev_close' => 128,
+        'weight_pct' => 5.0,
+    ];
+    $analysis = $signals->analyze($userId, $holding, ['prev_close' => 128], ['user_id' => $userId, 'default_target' => 10]);
+    if (empty($analysis['signals'])) {
+        throw new RuntimeException('Signals should not be empty');
+    }
+
+    echo "TradeService + SignalsService tests passed\n";
+    $pdo->rollBack();
+} catch (Throwable $e) {
+    $pdo->rollBack();
+    fwrite(STDERR, 'Test failed: ' . $e->getMessage() . "\n");
+    exit(1);
+}

--- a/views/errors/404.php
+++ b/views/errors/404.php
@@ -1,0 +1,4 @@
+<section class="min-h-[40vh] flex flex-col items-center justify-center text-center space-y-4">
+  <h1 class="text-4xl font-semibold text-gray-900 dark:text-gray-100">Not found</h1>
+  <p class="text-gray-500">We could not find the requested stock. Try returning to the <a href="/stocks" class="text-emerald-500 hover:underline">portfolio overview</a>.</p>
+</section>

--- a/views/layout/header.php
+++ b/views/layout/header.php
@@ -845,7 +845,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous"></script>
   <script>
     function themeState() {
       return {

--- a/views/layout/header.php
+++ b/views/layout/header.php
@@ -845,7 +845,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
   <script>
     function themeState() {
       return {

--- a/views/stocks/index.php
+++ b/views/stocks/index.php
@@ -5,6 +5,7 @@
 /** @var array $filters */
 /** @var int $refreshSeconds */
 /** @var array $userCurrencies */
+/** @var null|string $error */
 
 $totals = $overview['totals'];
 $holdings = $overview['holdings'];
@@ -14,6 +15,11 @@ $baseCurrency = $totals['base_currency'];
 ?>
 
 <section class="space-y-6">
+  <?php if (!empty($error) && $error === 'trade'): ?>
+    <div class="rounded-xl border border-amber-200 bg-amber-50 text-amber-800 px-4 py-3 text-sm">
+      Unable to record the trade. Please ensure the latest database migrations have been run and try again.
+    </div>
+  <?php endif; ?>
   <header class="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
     <div>
       <h1 class="text-3xl font-semibold text-gray-900 dark:text-gray-100">Stocks</h1>

--- a/views/stocks/index.php
+++ b/views/stocks/index.php
@@ -210,6 +210,10 @@ $baseCurrency = $totals['base_currency'];
         <h3 class="text-lg font-semibold">Import trades from CSV</h3>
         <p class="text-xs text-gray-500">Upload broker exports to backfill BUY/SELL activity. Cash top-ups, withdrawals, and dividends are kept out of positions automatically.</p>
       </div>
+      <form method="post" action="/stocks/clear" onsubmit="return confirm('Clear all recorded stock trades? This cannot be undone.');" class="shrink-0">
+        <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+        <button class="btn btn-danger">Clear history</button>
+      </form>
     </div>
     <form method="post" action="/stocks/import" enctype="multipart/form-data" class="space-y-3">
       <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />

--- a/views/stocks/index.php
+++ b/views/stocks/index.php
@@ -422,7 +422,7 @@ $formatQuantity = static function ($qty): string {
   <?php endif; ?>
 </section>
 
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
 <script>
 (function(){
   const allocationData = <?= json_encode($allocations['by_ticker']) ?>;

--- a/views/stocks/index.php
+++ b/views/stocks/index.php
@@ -65,6 +65,13 @@ $formatQuantity = static function ($qty): string {
     <article class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
       <h2 class="text-sm font-medium text-gray-500 uppercase tracking-wide">Total Market Value</h2>
       <p class="text-3xl font-semibold mt-2"><?= moneyfmt($totals['total_market_value'], $baseCurrency) ?></p>
+      <?php if (!empty($totals['total_market_value_by_currency'])): ?>
+        <ul class="mt-3 space-y-1 text-xs text-gray-500">
+          <?php foreach ($totals['total_market_value_by_currency'] as $currency => $amount): ?>
+            <li><?= moneyfmt($amount, $currency) ?></li>
+          <?php endforeach; ?>
+        </ul>
+      <?php endif; ?>
       <p class="text-xs text-gray-500">Trade cash flow: <?= moneyfmt($totals['cash_impact'], $baseCurrency) ?></p>
     </article>
     <article class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
@@ -73,6 +80,13 @@ $formatQuantity = static function ($qty): string {
         <?= moneyfmt($totals['unrealized_pl'], $baseCurrency) ?>
       </p>
       <p class="text-xs text-gray-500"><?= number_format($totals['unrealized_pct'], 2) ?>%</p>
+      <?php if (!empty($totals['unrealized_by_currency'])): ?>
+        <ul class="mt-3 space-y-1 text-xs <?= $totals['unrealized_pl'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>">
+          <?php foreach ($totals['unrealized_by_currency'] as $currency => $amount): ?>
+            <li><?= moneyfmt($amount, $currency) ?></li>
+          <?php endforeach; ?>
+        </ul>
+      <?php endif; ?>
     </article>
     <article class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
       <h2 class="text-sm font-medium text-gray-500 uppercase tracking-wide">Realized P/L (<?= htmlspecialchars($totals['realized_period']) ?>)</h2>
@@ -80,12 +94,26 @@ $formatQuantity = static function ($qty): string {
         <?= moneyfmt($totals['realized_pl'], $baseCurrency) ?>
       </p>
       <p class="text-xs text-gray-500">Daily P/L: <?= moneyfmt($totals['daily_pl'], $baseCurrency) ?></p>
+      <?php if (!empty($totals['realized_by_currency'])): ?>
+        <ul class="mt-3 space-y-1 text-xs <?= $totals['realized_pl'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>">
+          <?php foreach ($totals['realized_by_currency'] as $currency => $amount): ?>
+            <li><?= moneyfmt($amount, $currency) ?></li>
+          <?php endforeach; ?>
+        </ul>
+      <?php endif; ?>
     </article>
     <article class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
       <h2 class="text-sm font-medium text-gray-500 uppercase tracking-wide">Cash Balance</h2>
       <p class="text-3xl font-semibold mt-2 text-slate-700 dark:text-slate-100">
         <?= moneyfmt($totals['cash_balance'] ?? 0, $baseCurrency) ?>
       </p>
+      <?php if (!empty($totals['cash_by_currency'])): ?>
+        <ul class="mt-3 space-y-1 text-xs text-gray-500">
+          <?php foreach ($totals['cash_by_currency'] as $currency => $amount): ?>
+            <li><?= moneyfmt($amount, $currency) ?></li>
+          <?php endforeach; ?>
+        </ul>
+      <?php endif; ?>
       <?php if (!empty($cashEntries)): ?>
         <ul class="mt-3 space-y-1 text-xs text-gray-500 dark:text-gray-400">
           <?php foreach ($cashEntries as $entry): ?>
@@ -152,9 +180,13 @@ $formatQuantity = static function ($qty): string {
                 <td class="px-5 py-4 text-right <?= $holding['unrealized_base'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>">
                   <div data-role="holding-unrealized"><?= moneyfmt($holding['unrealized_base'], $baseCurrency) ?></div>
                   <div class="text-xs text-gray-400" data-role="holding-unrealized-ccy"><?= moneyfmt($holding['unrealized_ccy'], $holding['currency']) ?></div>
+                  <?php if ($holding['unrealized_pct'] !== null): ?>
+                    <div class="text-xs font-medium <?= $holding['unrealized_base'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>"><?= number_format($holding['unrealized_pct'], 2) ?>%</div>
+                  <?php endif; ?>
                 </td>
                 <td class="px-5 py-4 text-right <?= $holding['day_pl_base'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>" data-role="holding-day">
-                  <?= moneyfmt($holding['day_pl_base'], $baseCurrency) ?>
+                  <div><?= moneyfmt($holding['day_pl_base'], $baseCurrency) ?></div>
+                  <div class="text-xs text-gray-400"><?= moneyfmt($holding['day_pl_ccy'], $holding['currency']) ?></div>
                 </td>
                 <td class="px-5 py-4 text-right">
                   <?= number_format($holding['weight_pct'], 2) ?>%

--- a/views/stocks/index.php
+++ b/views/stocks/index.php
@@ -20,6 +20,18 @@ $baseCurrency = $totals['base_currency'];
       Unable to record the trade. Please ensure the latest database migrations have been run and try again.
     </div>
   <?php endif; ?>
+  <?php if (!empty($_SESSION['flash_success'])): ?>
+    <div class="rounded-xl border border-emerald-200 bg-emerald-50/90 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/15 dark:text-emerald-100">
+      <?= htmlspecialchars($_SESSION['flash_success']) ?>
+    </div>
+    <?php unset($_SESSION['flash_success']); ?>
+  <?php endif; ?>
+  <?php if (!empty($_SESSION['flash'])): ?>
+    <div class="rounded-xl border border-rose-200 bg-rose-50/90 px-4 py-3 text-sm text-rose-700 dark:border-rose-500/40 dark:bg-rose-500/15 dark:text-rose-100">
+      <?= htmlspecialchars($_SESSION['flash']) ?>
+    </div>
+    <?php unset($_SESSION['flash']); ?>
+  <?php endif; ?>
   <header class="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
     <div>
       <h1 class="text-3xl font-semibold text-gray-900 dark:text-gray-100">Stocks</h1>
@@ -189,6 +201,21 @@ $baseCurrency = $totals['base_currency'];
       <input name="trade_time" type="time" value="<?= date('H:i') ?>" class="input" />
       <input name="note" placeholder="Note" class="input sm:col-span-2" />
       <button class="btn btn-primary sm:col-span-2">Submit trade</button>
+    </form>
+  </section>
+
+  <section class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
+    <div class="flex items-start justify-between gap-4 mb-4">
+      <div>
+        <h3 class="text-lg font-semibold">Import trades from CSV</h3>
+        <p class="text-xs text-gray-500">Upload broker exports to backfill BUY/SELL activity. Cash top-ups, withdrawals, and dividends are kept out of positions automatically.</p>
+      </div>
+    </div>
+    <form method="post" action="/stocks/import" enctype="multipart/form-data" class="space-y-3">
+      <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+      <input type="file" name="csv" accept=".csv,text/csv" class="input" required />
+      <p class="text-xs text-gray-500">We match columns named Date, Ticker/Symbol, Type, Quantity, Price per share, Total Amount, Currency, and Fee when available.</p>
+      <button class="btn btn-secondary">Upload CSV</button>
     </form>
   </section>
 

--- a/views/stocks/index.php
+++ b/views/stocks/index.php
@@ -4,6 +4,7 @@
 /** @var array $portfolioChart */
 /** @var array $filters */
 /** @var int $refreshSeconds */
+/** @var array $userCurrencies */
 
 $totals = $overview['totals'];
 $holdings = $overview['holdings'];
@@ -160,11 +161,26 @@ $baseCurrency = $totals['base_currency'];
       </select>
       <input name="quantity" type="number" step="0.0001" placeholder="Qty" class="input" required />
       <input name="price" type="number" step="0.0001" placeholder="Price" class="input" required />
-      <input name="currency" placeholder="USD" class="input" />
+      <select name="currency" class="input">
+        <?php if (!empty($userCurrencies)): ?>
+          <?php $hasSelected = false; ?>
+          <?php foreach ($userCurrencies as $index => $c): ?>
+            <?php
+              $code = strtoupper($c['code']);
+              $isSelected = !empty($c['is_main']) || (!$hasSelected && $index === 0);
+              if ($isSelected) { $hasSelected = true; }
+            ?>
+            <option value="<?= htmlspecialchars($code) ?>" <?= $isSelected ? 'selected' : '' ?>>
+              <?= htmlspecialchars($code) ?>
+            </option>
+          <?php endforeach; ?>
+        <?php else: ?>
+          <option value="USD" selected>USD</option>
+        <?php endif; ?>
+      </select>
       <input name="fee" type="number" step="0.01" placeholder="Fee" class="input" />
       <input name="trade_date" type="date" value="<?= date('Y-m-d') ?>" class="input" />
       <input name="trade_time" type="time" value="<?= date('H:i') ?>" class="input" />
-      <input name="market" placeholder="NASDAQ" class="input" />
       <input name="note" placeholder="Note" class="input sm:col-span-2" />
       <button class="btn btn-primary sm:col-span-2">Submit trade</button>
     </form>

--- a/views/stocks/index.php
+++ b/views/stocks/index.php
@@ -191,7 +191,7 @@ $baseCurrency = $totals['base_currency'];
   <?php endif; ?>
 </section>
 
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-lY+UZiVRbnlM1c01qmPvvrLpzjAU6YewsGmmKzBSSMSmc5QwDFi1Cdm42Hcps225" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous"></script>
 <script>
 (function(){
   const allocationData = <?= json_encode($allocations['by_ticker']) ?>;

--- a/views/stocks/index.php
+++ b/views/stocks/index.php
@@ -59,6 +59,11 @@ $formatQuantity = static function ($qty): string {
       <p class="text-sm text-gray-500">A live look at your equity exposure, performance, and cash firepower.</p>
     </div>
     <div class="flex flex-wrap gap-2">
+      <form method="post" action="/stocks/refresh" class="inline-flex">
+        <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+        <input type="hidden" name="return_to" value="<?= htmlspecialchars($_SERVER['REQUEST_URI'] ?? '/stocks', ENT_QUOTES) ?>" />
+        <button class="btn btn-ghost" type="submit">Refresh quotes</button>
+      </form>
       <a href="/stocks/transactions" class="btn btn-ghost">Transactions</a>
       <button type="button" class="btn btn-secondary" data-dialog-open="cashDialog">Record cash</button>
       <button type="button" class="btn btn-primary" data-dialog-open="tradeDialog">New trade</button>

--- a/views/stocks/index.php
+++ b/views/stocks/index.php
@@ -77,6 +77,7 @@ $formatQuantity = static function ($qty): string {
         <input type="hidden" name="sector" value="<?= htmlspecialchars($filters['sector'] ?? '') ?>" />
         <input type="hidden" name="currency" value="<?= htmlspecialchars($filters['currency'] ?? '') ?>" />
         <input type="hidden" name="period" value="<?= htmlspecialchars($filters['realized_period'] ?? 'YTD') ?>" />
+        <input type="hidden" name="format" value="json" />
         <?php if (!empty($filters['watchlist_only'])): ?>
           <input type="hidden" name="watchlist" value="1" />
         <?php endif; ?>
@@ -575,8 +576,16 @@ $formatQuantity = static function ($qty): string {
         const resp = await fetch(refreshForm.action, {
           method: 'POST',
           body: new FormData(refreshForm),
-          headers: { 'Accept': 'application/json' }
+          credentials: 'same-origin',
+          headers: {
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest'
+          }
         });
+        const contentType = resp.headers.get('content-type') || '';
+        if (!contentType.includes('application/json')) {
+          throw new Error('Unexpected response from server.');
+        }
         const payload = await resp.json();
         if (!resp.ok || !payload.success) {
           throw new Error(payload && payload.message ? payload.message : 'Unable to refresh quotes');

--- a/views/stocks/index.php
+++ b/views/stocks/index.php
@@ -1,78 +1,317 @@
-<section class="grid md:grid-cols-3 gap-4">
-  <div class="card">
-    <h2 class="font-medium">Portfolio (cost basis)</h2>
-    <p class="text-2xl mt-2 font-semibold"><?= moneyfmt($portfolio_value) ?></p>
-    <p class="text-xs text-gray-500">Sum of qty × avg buy price for open positions.</p>
-  </div>
-  <div class="card md:col-span-2">
-    <h3 class="font-semibold mb-3">Trade — Buy</h3>
-    <form class="grid sm:grid-cols-6 gap-2" method="post" action="/stocks/buy">
-      <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
-      <input name="symbol" class="input sm:col-span-1" placeholder="AAPL" required>
-      <input name="quantity" type="number" step="0.000001" class="input sm:col-span-1" placeholder="Qty" required>
-      <input name="price" type="number" step="0.0001" class="input sm:col-span-1" placeholder="Price" required>
-      <input name="currency" class="input sm:col-span-1" value="USD">
-      <input name="trade_on" type="date" value="<?= date('Y-m-d') ?>" class="input sm:col-span-1">
-      <button class="btn btn-primary sm:col-span-1"><?= __('Buy') ?></button>
-    </form>
+<?php
+/** @var array $overview */
+/** @var array $insights */
+/** @var array $portfolioChart */
+/** @var array $filters */
+/** @var int $refreshSeconds */
 
-    <h3 class="font-semibold mt-6 mb-3">Trade — Sell</h3>
-    <form class="grid sm:grid-cols-6 gap-2" method="post" action="/stocks/sell">
-      <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
-      <input name="symbol" class="input sm:col-span-1" placeholder="AAPL" required>
-      <input name="quantity" type="number" step="0.000001" class="input sm:col-span-1" placeholder="Qty" required>
-      <input name="price" type="number" step="0.0001" class="input sm:col-span-1" placeholder="Price" required>
-      <input name="currency" class="input sm:col-span-1" value="USD">
-      <input name="trade_on" type="date" value="<?= date('Y-m-d') ?>" class="input sm:col-span-1">
-      <button class="btn btn-danger sm:col-span-1"><?= __('Sell') ?></button>
+$totals = $overview['totals'];
+$holdings = $overview['holdings'];
+$allocations = $overview['allocations'];
+$watchlist = $overview['watchlist'];
+$baseCurrency = $totals['base_currency'];
+?>
+
+<section class="space-y-6">
+  <header class="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+    <div>
+      <h1 class="text-3xl font-semibold text-gray-900 dark:text-gray-100">Stocks</h1>
+      <p class="text-sm text-gray-500">Live overview of your equity portfolio across currencies.</p>
+    </div>
+    <form method="get" action="/stocks" class="grid grid-cols-1 sm:grid-cols-5 gap-2">
+      <input type="search" name="q" value="<?= htmlspecialchars($filters['search'] ?? '') ?>" placeholder="Search ticker" class="input sm:col-span-2" />
+      <input type="text" name="sector" value="<?= htmlspecialchars($filters['sector'] ?? '') ?>" placeholder="Sector" class="input" />
+      <input type="text" name="currency" value="<?= htmlspecialchars($filters['currency'] ?? '') ?>" placeholder="Currency" class="input" />
+      <select name="period" class="input">
+        <?php $period = strtoupper($filters['realized_period'] ?? 'YTD'); ?>
+        <?php foreach(['YTD','1M','3M','1Y','ALL'] as $opt): ?>
+          <option value="<?= $opt ?>" <?= $period === $opt ? 'selected' : '' ?>>Realized <?= $opt ?></option>
+        <?php endforeach; ?>
+      </select>
+      <label class="inline-flex items-center justify-center rounded-lg bg-white/70 dark:bg-gray-900/40 border border-gray-200/70 px-3 text-sm font-medium text-gray-600 shadow-sm">
+        <input type="checkbox" name="watchlist" value="1" <?= !empty($filters['watchlist_only']) ? 'checked' : '' ?> class="mr-2" />Watchlist only
+      </label>
+      <button class="btn btn-primary sm:col-span-1">Apply</button>
     </form>
-  </div>
+  </header>
+
+  <section class="grid md:grid-cols-3 gap-4">
+    <article class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
+      <h2 class="text-sm font-medium text-gray-500 uppercase tracking-wide">Total Market Value</h2>
+      <p class="text-3xl font-semibold mt-2"><?= moneyfmt($totals['total_market_value'], $baseCurrency) ?></p>
+      <p class="text-xs text-gray-500">Cash impact: <?= moneyfmt($totals['cash_impact'], $baseCurrency) ?></p>
+    </article>
+    <article class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
+      <h2 class="text-sm font-medium text-gray-500 uppercase tracking-wide">Unrealized P/L</h2>
+      <p class="text-3xl font-semibold mt-2 <?= $totals['unrealized_pl'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>">
+        <?= moneyfmt($totals['unrealized_pl'], $baseCurrency) ?>
+      </p>
+      <p class="text-xs text-gray-500"><?= number_format($totals['unrealized_pct'], 2) ?>%</p>
+    </article>
+    <article class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
+      <h2 class="text-sm font-medium text-gray-500 uppercase tracking-wide">Realized P/L (<?= htmlspecialchars($totals['realized_period']) ?>)</h2>
+      <p class="text-3xl font-semibold mt-2 <?= $totals['realized_pl'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>">
+        <?= moneyfmt($totals['realized_pl'], $baseCurrency) ?>
+      </p>
+      <p class="text-xs text-gray-500">Daily P/L: <?= moneyfmt($totals['daily_pl'], $baseCurrency) ?></p>
+    </article>
+  </section>
+
+  <section class="grid lg:grid-cols-5 gap-6">
+    <div class="lg:col-span-3 card overflow-hidden shadow-md bg-white/80 dark:bg-gray-900/40">
+      <div class="flex items-center justify-between px-5 py-4 border-b border-gray-200/70 dark:border-gray-800">
+        <h3 class="text-lg font-semibold">Current holdings</h3>
+        <span class="text-xs text-gray-500">Base currency: <?= htmlspecialchars($baseCurrency) ?></span>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead class="bg-gray-50/70 dark:bg-gray-900/60 text-gray-600 uppercase text-xs tracking-wide">
+            <tr>
+              <th class="px-5 py-3 text-left">Ticker</th>
+              <th class="px-5 py-3 text-right">Qty</th>
+              <th class="px-5 py-3 text-right">Avg Cost</th>
+              <th class="px-5 py-3 text-right">Last</th>
+              <th class="px-5 py-3 text-right">Market Value</th>
+              <th class="px-5 py-3 text-right">Unrealized</th>
+              <th class="px-5 py-3 text-right">Day P/L</th>
+              <th class="px-5 py-3 text-right">Weight</th>
+              <th class="px-5 py-3 text-left">Insights</th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php if (empty($holdings)): ?>
+              <tr>
+                <td colspan="9" class="px-5 py-6 text-center text-gray-500">No holdings yet. Record your first trade below.</td>
+              </tr>
+            <?php endif; ?>
+            <?php foreach ($holdings as $holding):
+              $symbol = $holding['symbol'];
+              $suggestions = $insights[$symbol]['suggestions'] ?? [];
+              $signals = $insights[$symbol]['signals'] ?? [];
+            ?>
+              <tr class="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50/70 dark:hover:bg-gray-900/40" data-symbol="<?= htmlspecialchars($symbol) ?>" data-qty="<?= htmlspecialchars($holding['qty']) ?>" data-avg="<?= htmlspecialchars($holding['avg_cost']) ?>" data-currency="<?= htmlspecialchars($holding['currency']) ?>">
+                <td class="px-5 py-4 font-semibold text-gray-900 dark:text-gray-100">
+                  <a href="/stocks/<?= urlencode($symbol) ?>" class="hover:text-emerald-500 transition"><?= htmlspecialchars($symbol) ?></a>
+                  <span class="block text-xs text-gray-500"><?= htmlspecialchars($holding['name'] ?? '') ?></span>
+                </td>
+                <td class="px-5 py-4 text-right"><?= number_format($holding['qty'], 4) ?></td>
+                <td class="px-5 py-4 text-right">
+                  <?= moneyfmt($holding['avg_cost'], $holding['currency']) ?>
+                </td>
+                <td class="px-5 py-4 text-right" data-role="holding-last">
+                  <?= $holding['last_price'] !== null ? moneyfmt($holding['last_price'], $holding['currency']) : '<span class="text-xs text-gray-400">stale</span>' ?>
+                </td>
+                <td class="px-5 py-4 text-right">
+                  <div data-role="holding-market"><?= moneyfmt($holding['market_value_base'], $baseCurrency) ?></div>
+                  <div class="text-xs text-gray-400" data-role="holding-market-ccy"><?= moneyfmt($holding['market_value_ccy'], $holding['currency']) ?></div>
+                </td>
+                <td class="px-5 py-4 text-right <?= $holding['unrealized_base'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>">
+                  <div data-role="holding-unrealized"><?= moneyfmt($holding['unrealized_base'], $baseCurrency) ?></div>
+                  <div class="text-xs text-gray-400" data-role="holding-unrealized-ccy"><?= moneyfmt($holding['unrealized_ccy'], $holding['currency']) ?></div>
+                </td>
+                <td class="px-5 py-4 text-right <?= $holding['day_pl_base'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>" data-role="holding-day">
+                  <?= moneyfmt($holding['day_pl_base'], $baseCurrency) ?>
+                </td>
+                <td class="px-5 py-4 text-right">
+                  <?= number_format($holding['weight_pct'], 2) ?>%
+                  <?php if (!empty($holding['risk_note'])): ?>
+                    <span class="block text-xs text-rose-500"><?= htmlspecialchars($holding['risk_note']) ?></span>
+                  <?php endif; ?>
+                </td>
+                <td class="px-5 py-4 text-left">
+                  <?php if (!empty($suggestions)): ?>
+                    <ul class="space-y-1 text-xs text-gray-600 dark:text-gray-300">
+                      <?php foreach ($suggestions as $suggestion): ?>
+                        <li>• <?= htmlspecialchars($suggestion) ?></li>
+                      <?php endforeach; ?>
+                    </ul>
+                  <?php elseif (!empty($signals)): ?>
+                    <span class="text-xs text-gray-500">Balanced</span>
+                  <?php else: ?>
+                    <span class="text-xs text-gray-400">–</span>
+                  <?php endif; ?>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="lg:col-span-2 space-y-6">
+      <div class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
+        <h3 class="text-lg font-semibold mb-3">Allocation by ticker</h3>
+        <canvas id="allocationTickerChart" height="220"></canvas>
+      </div>
+      <div class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
+        <h3 class="text-lg font-semibold mb-3">Portfolio value</h3>
+        <canvas id="portfolioValueChart" height="220"></canvas>
+      </div>
+    </div>
+  </section>
+
+  <section class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
+    <h3 class="text-lg font-semibold mb-3">Record trade</h3>
+    <form method="post" action="/stocks/trade" class="grid sm:grid-cols-6 gap-3">
+      <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+      <input name="symbol" placeholder="AAPL" class="input" required />
+      <select name="side" class="input">
+        <option value="BUY">Buy</option>
+        <option value="SELL">Sell</option>
+      </select>
+      <input name="quantity" type="number" step="0.0001" placeholder="Qty" class="input" required />
+      <input name="price" type="number" step="0.0001" placeholder="Price" class="input" required />
+      <input name="currency" placeholder="USD" class="input" />
+      <input name="fee" type="number" step="0.01" placeholder="Fee" class="input" />
+      <input name="trade_date" type="date" value="<?= date('Y-m-d') ?>" class="input" />
+      <input name="trade_time" type="time" value="<?= date('H:i') ?>" class="input" />
+      <input name="market" placeholder="NASDAQ" class="input" />
+      <input name="note" placeholder="Note" class="input sm:col-span-2" />
+      <button class="btn btn-primary sm:col-span-2">Submit trade</button>
+    </form>
+  </section>
+
+  <?php if (!empty($watchlist)): ?>
+  <section class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
+    <h3 class="text-lg font-semibold mb-4">Watchlist</h3>
+    <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4" id="watchlistStrip">
+      <?php foreach ($watchlist as $item): ?>
+        <article class="p-4 rounded-2xl border border-gray-100 dark:border-gray-800 bg-white/60 dark:bg-gray-900/40 shadow-sm flex flex-col gap-1" data-symbol="<?= htmlspecialchars($item['symbol']) ?>">
+          <div class="flex items-center justify-between">
+            <a href="/stocks/<?= urlencode($item['symbol']) ?>" class="font-semibold text-gray-900 dark:text-gray-100"><?= htmlspecialchars($item['symbol']) ?></a>
+            <span class="text-xs text-gray-500"><?= htmlspecialchars($item['currency']) ?></span>
+          </div>
+          <div class="text-xl font-semibold text-gray-800 dark:text-gray-100" data-role="last">
+            <?= $item['last_price'] !== null ? moneyfmt($item['last_price'], $item['currency']) : '—' ?>
+          </div>
+          <div class="text-xs text-gray-500" data-role="change">Prev: <?= $item['prev_close'] !== null ? moneyfmt($item['prev_close'], $item['currency']) : '—' ?></div>
+        </article>
+      <?php endforeach; ?>
+    </div>
+  </section>
+  <?php endif; ?>
 </section>
 
-<section class="mt-6 grid md:grid-cols-2 gap-6">
-  <div class="card overflow-x-auto">
-    <h3 class="font-semibold mb-3">Open Positions</h3>
-    <table class="table-glass min-w-full text-sm">
-      <thead><tr class="text-left border-b"><th class="py-2 pr-3">Symbol</th><th class="py-2 pr-3">Qty</th><th class="py-2 pr-3">Avg Buy</th><th class="py-2 pr-3">Cost</th></tr></thead>
-      <tbody>
-        <?php foreach($positions as $p): if((float)$p['qty']<=0) continue; $cost=(float)$p['qty']*(float)$p['avg_buy_price']; ?>
-          <tr class="border-b">
-            <td class="py-2 pr-3 font-medium"><?= htmlspecialchars($p['symbol']) ?></td>
-            <td class="py-2 pr-3"><?= (float)$p['qty'] ?></td>
-            <td class="py-2 pr-3"><?= moneyfmt($p['avg_buy_price']) ?></td>
-            <td class="py-2 pr-3 font-medium"><?= moneyfmt($cost) ?></td>
-          </tr>
-        <?php endforeach; ?>
-      </tbody>
-    </table>
-  </div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-lY+UZiVRbnlM1c01qmPvvrLpzjAU6YewsGmmKzBSSMSmc5QwDFi1Cdm42Hcps225" crossorigin="anonymous"></script>
+<script>
+(function(){
+  const allocationData = <?= json_encode($allocations['by_ticker']) ?>;
+  const portfolioSeries = <?= json_encode($portfolioChart['series']) ?>;
+  const portfolioLabels = <?= json_encode($portfolioChart['labels']) ?>;
+  const holdings = <?= json_encode(array_map(fn($h)=>$h['symbol'], $holdings)) ?>;
+  const watchlist = <?= json_encode(array_map(fn($w)=>$w['symbol'], $watchlist)) ?>;
+  const refreshSeconds = <?= (int)$refreshSeconds ?> * 1000;
 
-  <div class="card overflow-x-auto">
-    <h3 class="font-semibold mb-3">Recent Trades</h3>
-    <table class="table-glass min-w-full text-sm">
-      <thead><tr class="text-left border-b"><th class="py-2 pr-3">Date</th><th class="py-2 pr-3">Side</th><th class="py-2 pr-3">Symbol</th><th class="py-2 pr-3">Qty</th><th class="py-2 pr-3">Price</th><th class="py-2 pr-3">Currency</th><th class="py-2 pr-3">Actions</th></tr></thead>
-      <tbody>
-        <?php foreach($trades as $t): ?>
-          <tr class="border-b">
-            <td class="py-2 pr-3"><?= htmlspecialchars($t['trade_on']) ?></td>
-            <td class="py-2 pr-3 capitalize"><?= htmlspecialchars($t['side']) ?></td>
-            <td class="py-2 pr-3 font-medium"><?= htmlspecialchars($t['symbol']) ?></td>
-            <td class="py-2 pr-3"><?= (float)$t['quantity'] ?></td>
-            <td class="py-2 pr-3"><?= moneyfmt($t['price']) ?></td>
-            <td class="py-2 pr-3"><?= htmlspecialchars($t['currency']) ?></td>
-            <td class="py-2 pr-3">
-              <form method="post" action="/stocks/trade/delete" onsubmit="return confirm('Delete trade?')">
-                <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
-                <input type="hidden" name="id" value="<?= $t['id'] ?>" />
-                <button class="icon-action icon-action--danger" title="<?= __('Remove') ?>">
-                  <i data-lucide="trash-2" class="h-4 w-4"></i>
-                  <span class="sr-only"><?= __('Remove') ?></span>
-                </button>
-              </form>
-            </td>
-          </tr>
-        <?php endforeach; ?>
-      </tbody>
-    </table>
-  </div>
-</section>
+  const allocationCtx = document.getElementById('allocationTickerChart');
+  if (allocationCtx && allocationData.length) {
+    const labels = allocationData.map(item => item.label);
+    const data = allocationData.map(item => item.weight_pct);
+    new Chart(allocationCtx, {
+      type: 'doughnut',
+      data: {
+        labels,
+        datasets: [{
+          data,
+          backgroundColor: labels.map((_, idx) => `rgba(76, 175, 80, ${0.8 - idx * 0.05})`)
+        }]
+      },
+      options: {
+        plugins: { legend: { position: 'bottom' } }
+      }
+    });
+  }
+
+  const valueCtx = document.getElementById('portfolioValueChart');
+  if (valueCtx && portfolioSeries.length) {
+    new Chart(valueCtx, {
+      type: 'line',
+      data: {
+        labels: portfolioLabels,
+        datasets: [{
+          data: portfolioSeries,
+          borderColor: '#34d399',
+          tension: 0.3,
+          fill: true,
+          backgroundColor: 'rgba(52, 211, 153, 0.12)'
+        }]
+      },
+      options: {
+        scales: {
+          x: { display: false },
+          y: { ticks: { callback: value => new Intl.NumberFormat(undefined, { style: 'currency', currency: '<?= $baseCurrency ?>' }).format(value) } }
+        },
+        plugins: { legend: { display: false } }
+      }
+    });
+  }
+
+  const symbols = Array.from(new Set([...holdings, ...watchlist]));
+  const panels = document.querySelectorAll('#watchlistStrip [data-symbol]');
+  const updatePanels = (quotes) => {
+    panels.forEach(panel => {
+      const symbol = panel.getAttribute('data-symbol');
+      const quote = quotes[symbol];
+      if (!quote) return;
+      const lastEl = panel.querySelector('[data-role="last"]');
+      const changeEl = panel.querySelector('[data-role="change"]');
+      if (lastEl && quote.last !== null) {
+        lastEl.textContent = new Intl.NumberFormat(undefined, { style: 'currency', currency: quote.currency || '<?= $baseCurrency ?>' }).format(quote.last);
+      }
+      if (changeEl && quote.prev_close !== null && quote.last !== null) {
+        const diff = quote.last - quote.prev_close;
+        const pct = quote.prev_close ? (diff / quote.prev_close) * 100 : 0;
+        changeEl.textContent = `${diff >= 0 ? '+' : ''}${diff.toFixed(2)} (${pct.toFixed(2)}%)`;
+        changeEl.classList.toggle('text-emerald-500', diff >= 0);
+        changeEl.classList.toggle('text-rose-500', diff < 0);
+      }
+    });
+    document.querySelectorAll('tr[data-symbol]').forEach(row => {
+      const symbol = row.getAttribute('data-symbol');
+      const quote = quotes[symbol];
+      if (!quote) return;
+      const currency = row.getAttribute('data-currency') || quote.currency || '<?= $baseCurrency ?>';
+      const qty = parseFloat(row.getAttribute('data-qty') || '0');
+      const avg = parseFloat(row.getAttribute('data-avg') || '0');
+      const lastCell = row.querySelector('[data-role="holding-last"]');
+      if (lastCell && quote.last !== null) {
+        lastCell.textContent = new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(quote.last);
+      }
+      const marketCcy = row.querySelector('[data-role="holding-market-ccy"]');
+      if (marketCcy && quote.last !== null) {
+        marketCcy.textContent = new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(qty * quote.last);
+      }
+      const unrealizedCcy = row.querySelector('[data-role="holding-unrealized-ccy"]');
+      if (quote.last !== null && unrealizedCcy) {
+        const diffCcy = (quote.last - avg) * qty;
+        unrealizedCcy.textContent = new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(diffCcy);
+      }
+    });
+  };
+
+  async function pollQuotes(){
+    if (!symbols.length) return;
+    try {
+      const resp = await fetch(`/api/stocks/live?symbols=${symbols.join(',')}`, { headers: { 'Accept': 'application/json' } });
+      if (!resp.ok) return;
+      const data = await resp.json();
+      if (data && data.quotes) {
+        const lookup = {};
+        data.quotes.forEach(q => { lookup[q.symbol] = q; });
+        updatePanels(lookup);
+      }
+    } catch (err) {
+      console.warn('Live quotes polling failed', err);
+    }
+  }
+
+  pollQuotes();
+  let pollTimer = setInterval(pollQuotes, refreshSeconds);
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      clearInterval(pollTimer);
+    } else {
+      pollQuotes();
+      pollTimer = setInterval(pollQuotes, refreshSeconds);
+    }
+  });
+})();
+</script>

--- a/views/stocks/partials/holdings_rows.php
+++ b/views/stocks/partials/holdings_rows.php
@@ -1,0 +1,64 @@
+<?php
+/** @var array $holdings */
+/** @var array $insights */
+/** @var string $baseCurrency */
+/** @var callable $formatQuantity */
+?>
+<?php if (empty($holdings)): ?>
+  <tr>
+    <td colspan="9" class="px-6 py-8 text-center text-gray-500">No holdings yet. Record your first trade to get started.</td>
+  </tr>
+<?php endif; ?>
+<?php foreach ($holdings as $holding):
+  $symbol = $holding['symbol'];
+  $suggestions = $insights[$symbol]['suggestions'] ?? [];
+  $signals = $insights[$symbol]['signals'] ?? [];
+?>
+  <tr class="hover:bg-gray-50/80 dark:hover:bg-gray-900/40 transition" data-symbol="<?= htmlspecialchars($symbol) ?>" data-qty="<?= htmlspecialchars($holding['qty']) ?>" data-avg="<?= htmlspecialchars($holding['avg_cost']) ?>" data-currency="<?= htmlspecialchars($holding['currency']) ?>">
+    <td class="px-6 py-4 font-semibold text-gray-900 dark:text-gray-100">
+      <a href="/stocks/<?= urlencode($symbol) ?>" class="hover:text-emerald-500 transition"><?= htmlspecialchars($symbol) ?></a>
+      <span class="block text-xs text-gray-500"><?= htmlspecialchars($holding['name'] ?? '') ?></span>
+    </td>
+    <td class="px-6 py-4 text-right font-mono text-xs sm:text-sm"><?= $formatQuantity($holding['qty']) ?></td>
+    <td class="px-6 py-4 text-right">
+      <?= moneyfmt($holding['avg_cost'], $holding['currency']) ?>
+    </td>
+    <td class="px-6 py-4 text-right" data-role="holding-last">
+      <?= $holding['last_price'] !== null ? moneyfmt($holding['last_price'], $holding['currency']) : '<span class="text-xs text-gray-400">stale</span>' ?>
+    </td>
+    <td class="px-6 py-4 text-right">
+      <div data-role="holding-market"><?= moneyfmt($holding['market_value_base'], $baseCurrency) ?></div>
+      <div class="text-xs text-gray-400" data-role="holding-market-ccy"><?= moneyfmt($holding['market_value_ccy'], $holding['currency']) ?></div>
+    </td>
+    <td class="px-6 py-4 text-right <?= $holding['unrealized_base'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>">
+      <div data-role="holding-unrealized"><?= moneyfmt($holding['unrealized_base'], $baseCurrency) ?></div>
+      <div class="text-xs text-gray-400" data-role="holding-unrealized-ccy"><?= moneyfmt($holding['unrealized_ccy'], $holding['currency']) ?></div>
+      <?php if ($holding['unrealized_pct'] !== null): ?>
+        <div class="text-xs font-medium <?= $holding['unrealized_base'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>"><?= number_format($holding['unrealized_pct'], 2) ?>%</div>
+      <?php endif; ?>
+    </td>
+    <td class="px-6 py-4 text-right <?= $holding['day_pl_base'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>" data-role="holding-day">
+      <div><?= moneyfmt($holding['day_pl_base'], $baseCurrency) ?></div>
+      <div class="text-xs text-gray-400"><?= moneyfmt($holding['day_pl_ccy'], $holding['currency']) ?></div>
+    </td>
+    <td class="px-6 py-4 text-right">
+      <?= number_format($holding['weight_pct'], 2) ?>%
+      <?php if (!empty($holding['risk_note'])): ?>
+        <span class="block text-xs text-rose-500"><?= htmlspecialchars($holding['risk_note']) ?></span>
+      <?php endif; ?>
+    </td>
+    <td class="px-6 py-4 text-left">
+      <?php if (!empty($suggestions)): ?>
+        <ul class="space-y-1 text-xs text-gray-600 dark:text-gray-300">
+          <?php foreach ($suggestions as $suggestion): ?>
+            <li>• <?= htmlspecialchars($suggestion) ?></li>
+          <?php endforeach; ?>
+        </ul>
+      <?php elseif (!empty($signals)): ?>
+        <span class="text-xs text-gray-500">Balanced</span>
+      <?php else: ?>
+        <span class="text-xs text-gray-400">–</span>
+      <?php endif; ?>
+    </td>
+  </tr>
+<?php endforeach; ?>

--- a/views/stocks/partials/holdings_rows.php
+++ b/views/stocks/partials/holdings_rows.php
@@ -13,8 +13,37 @@
   $symbol = $holding['symbol'];
   $suggestions = $insights[$symbol]['suggestions'] ?? [];
   $signals = $insights[$symbol]['signals'] ?? [];
+  $marketValueCcy = (float)$holding['market_value_ccy'];
+  $marketValueBase = (float)$holding['market_value_base'];
+  $unrealizedBase = (float)$holding['unrealized_base'];
+  $unrealizedCcy = (float)$holding['unrealized_ccy'];
+  $dayBase = (float)$holding['day_pl_base'];
+  $dayCcy = (float)$holding['day_pl_ccy'];
+  $costBase = (float)$holding['cost_base'];
+  $prevClose = $holding['prev_close'] ?? null;
+  $lastPrice = $holding['last_price'] ?? null;
+  $fxRate = 1.0;
+  if ($holding['currency'] !== $baseCurrency) {
+    $fxRate = ($marketValueCcy != 0.0) ? $marketValueBase / $marketValueCcy : 1.0;
+  }
 ?>
-  <tr class="hover:bg-gray-50/80 dark:hover:bg-gray-900/40 transition" data-symbol="<?= htmlspecialchars($symbol) ?>" data-qty="<?= htmlspecialchars($holding['qty']) ?>" data-avg="<?= htmlspecialchars($holding['avg_cost']) ?>" data-currency="<?= htmlspecialchars($holding['currency']) ?>">
+  <tr
+    class="hover:bg-gray-50/80 dark:hover:bg-gray-900/40 transition"
+    data-symbol="<?= htmlspecialchars($symbol) ?>"
+    data-qty="<?= htmlspecialchars($holding['qty']) ?>"
+    data-avg="<?= htmlspecialchars($holding['avg_cost']) ?>"
+    data-currency="<?= htmlspecialchars($holding['currency']) ?>"
+    data-last="<?= $lastPrice !== null ? htmlspecialchars((string)$lastPrice) : '' ?>"
+    data-prev="<?= $prevClose !== null ? htmlspecialchars((string)$prevClose) : '' ?>"
+    data-fx="<?= htmlspecialchars((string)$fxRate) ?>"
+    data-market-base="<?= htmlspecialchars((string)$marketValueBase) ?>"
+    data-market-ccy="<?= htmlspecialchars((string)$marketValueCcy) ?>"
+    data-unrealized-base="<?= htmlspecialchars((string)$unrealizedBase) ?>"
+    data-unrealized-ccy="<?= htmlspecialchars((string)$unrealizedCcy) ?>"
+    data-day-base="<?= htmlspecialchars((string)$dayBase) ?>"
+    data-day-ccy="<?= htmlspecialchars((string)$dayCcy) ?>"
+    data-cost-base="<?= htmlspecialchars((string)$costBase) ?>"
+  >
     <td class="px-6 py-4 font-semibold text-gray-900 dark:text-gray-100">
       <a href="/stocks/<?= urlencode($symbol) ?>" class="hover:text-emerald-500 transition"><?= htmlspecialchars($symbol) ?></a>
       <span class="block text-xs text-gray-500"><?= htmlspecialchars($holding['name'] ?? '') ?></span>
@@ -27,25 +56,25 @@
       <?= $holding['last_price'] !== null ? moneyfmt($holding['last_price'], $holding['currency']) : '<span class="text-xs text-gray-400">stale</span>' ?>
     </td>
     <td class="px-6 py-4 text-right">
-      <div data-role="holding-market"><?= moneyfmt($holding['market_value_base'], $baseCurrency) ?></div>
+      <div data-role="holding-market-base"><?= moneyfmt($holding['market_value_base'], $baseCurrency) ?></div>
       <div class="text-xs text-gray-400" data-role="holding-market-ccy"><?= moneyfmt($holding['market_value_ccy'], $holding['currency']) ?></div>
     </td>
-    <td class="px-6 py-4 text-right <?= $holding['unrealized_base'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>">
-      <div data-role="holding-unrealized"><?= moneyfmt($holding['unrealized_base'], $baseCurrency) ?></div>
+    <td class="px-6 py-4 text-right <?= $holding['unrealized_base'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>" data-role="holding-unrealized-cell">
+      <div data-role="holding-unrealized-base"><?= moneyfmt($holding['unrealized_base'], $baseCurrency) ?></div>
       <div class="text-xs text-gray-400" data-role="holding-unrealized-ccy"><?= moneyfmt($holding['unrealized_ccy'], $holding['currency']) ?></div>
       <?php if ($holding['unrealized_pct'] !== null): ?>
-        <div class="text-xs font-medium <?= $holding['unrealized_base'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>"><?= number_format($holding['unrealized_pct'], 2) ?>%</div>
+        <div class="text-xs font-medium <?= $holding['unrealized_base'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>" data-role="holding-unrealized-pct"><?= number_format($holding['unrealized_pct'], 2) ?>%</div>
       <?php endif; ?>
     </td>
-    <td class="px-6 py-4 text-right <?= $holding['day_pl_base'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>" data-role="holding-day">
-      <div><?= moneyfmt($holding['day_pl_base'], $baseCurrency) ?></div>
-      <div class="text-xs text-gray-400"><?= moneyfmt($holding['day_pl_ccy'], $holding['currency']) ?></div>
+    <td class="px-6 py-4 text-right <?= $holding['day_pl_base'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>" data-role="holding-day-cell">
+      <div data-role="holding-day-base"><?= moneyfmt($holding['day_pl_base'], $baseCurrency) ?></div>
+      <div class="text-xs text-gray-400" data-role="holding-day-ccy"><?= moneyfmt($holding['day_pl_ccy'], $holding['currency']) ?></div>
     </td>
     <td class="px-6 py-4 text-right">
-      <?= number_format($holding['weight_pct'], 2) ?>%
-      <?php if (!empty($holding['risk_note'])): ?>
-        <span class="block text-xs text-rose-500"><?= htmlspecialchars($holding['risk_note']) ?></span>
-      <?php endif; ?>
+      <span data-role="holding-weight"><?= number_format($holding['weight_pct'], 2) ?></span>%
+      <span class="block text-xs text-rose-500<?= empty($holding['risk_note']) ? ' hidden' : '' ?>" data-role="holding-risk">
+        <?= !empty($holding['risk_note']) ? htmlspecialchars($holding['risk_note']) : '' ?>
+      </span>
     </td>
     <td class="px-6 py-4 text-left">
       <?php if (!empty($suggestions)): ?>

--- a/views/stocks/partials/overview_cards.php
+++ b/views/stocks/partials/overview_cards.php
@@ -1,0 +1,80 @@
+<?php
+/** @var array $totals */
+/** @var string $baseCurrency */
+/** @var array $marketByCurrency */
+/** @var array $unrealizedByCurrency */
+/** @var array $realizedByCurrency */
+/** @var array $cashEntries */
+/** @var array $cashByCurrency */
+/** @var string $preferredCurrency */
+/** @var float|null $preferredMarket */
+/** @var float|null $preferredUnrealized */
+/** @var float|null $preferredRealized */
+/** @var float|null $preferredCash */
+?>
+<article class="rounded-2xl border border-gray-200/70 bg-white/80 p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900/40">
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500">Total Market Value</h2>
+  <p class="mt-3 text-2xl font-semibold text-gray-900 dark:text-gray-100"><?= moneyfmt($totals['total_market_value'], $baseCurrency) ?></p>
+  <?php if ($preferredMarket !== null): ?>
+    <p class="text-sm text-gray-500">≈ <?= moneyfmt($preferredMarket, $preferredCurrency) ?></p>
+  <?php endif; ?>
+  <?php if (!empty($marketByCurrency)): ?>
+    <ul class="mt-3 space-y-1 text-xs text-gray-500">
+      <?php foreach ($marketByCurrency as $currency => $amount): ?>
+        <li><?= moneyfmt($amount, $currency) ?></li>
+      <?php endforeach; ?>
+    </ul>
+  <?php endif; ?>
+</article>
+<article class="rounded-2xl border border-gray-200/70 bg-white/80 p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900/40">
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500">Unrealized P/L</h2>
+  <p class="mt-3 text-2xl font-semibold <?= $totals['unrealized_pl'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>">
+    <?= moneyfmt($totals['unrealized_pl'], $baseCurrency) ?>
+  </p>
+  <?php if ($preferredUnrealized !== null): ?>
+    <p class="text-sm text-gray-500">≈ <?= moneyfmt($preferredUnrealized, $preferredCurrency) ?></p>
+  <?php endif; ?>
+  <p class="text-xs text-gray-500 mt-1"><?= number_format($totals['unrealized_pct'], 2) ?>%</p>
+  <?php if (!empty($unrealizedByCurrency)): ?>
+    <ul class="mt-3 space-y-1 text-xs <?= $totals['unrealized_pl'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>">
+      <?php foreach ($unrealizedByCurrency as $currency => $amount): ?>
+        <li><?= moneyfmt($amount, $currency) ?></li>
+      <?php endforeach; ?>
+    </ul>
+  <?php endif; ?>
+</article>
+<article class="rounded-2xl border border-gray-200/70 bg-white/80 p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900/40">
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500">Realized P/L (<?= htmlspecialchars($totals['realized_period']) ?>)</h2>
+  <p class="mt-3 text-2xl font-semibold <?= $totals['realized_pl'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>">
+    <?= moneyfmt($totals['realized_pl'], $baseCurrency) ?>
+  </p>
+  <?php if ($preferredRealized !== null): ?>
+    <p class="text-sm text-gray-500">≈ <?= moneyfmt($preferredRealized, $preferredCurrency) ?></p>
+  <?php endif; ?>
+  <p class="text-xs text-gray-500 mt-1">Daily P/L: <?= moneyfmt($totals['daily_pl'], $baseCurrency) ?></p>
+  <?php if (!empty($realizedByCurrency)): ?>
+    <ul class="mt-3 space-y-1 text-xs <?= $totals['realized_pl'] >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>">
+      <?php foreach ($realizedByCurrency as $currency => $amount): ?>
+        <li><?= moneyfmt($amount, $currency) ?></li>
+      <?php endforeach; ?>
+    </ul>
+  <?php endif; ?>
+</article>
+<article class="rounded-2xl border border-gray-200/70 bg-white/80 p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900/40">
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500">Cash Balance</h2>
+  <p class="mt-3 text-2xl font-semibold text-slate-800 dark:text-slate-100">
+    <?= moneyfmt($totals['cash_balance'] ?? 0, $baseCurrency) ?>
+  </p>
+  <?php if ($preferredCash !== null): ?>
+    <p class="text-sm text-gray-500">≈ <?= moneyfmt($preferredCash, $preferredCurrency) ?></p>
+  <?php endif; ?>
+  <?php if (!empty($cashEntries)): ?>
+    <ul class="mt-3 space-y-1 text-xs text-gray-500 dark:text-gray-400">
+      <?php foreach ($cashEntries as $entry): ?>
+        <li><?= moneyfmt($entry['amount'], $entry['currency']) ?> <span class="text-[11px] text-gray-400">(<?= moneyfmt($entry['amount_base'], $baseCurrency) ?>)</span></li>
+      <?php endforeach; ?>
+    </ul>
+  <?php else: ?>
+    <p class="text-xs text-gray-500 mt-3">No cash entries yet.</p>
+  <?php endif; ?>
+</article>

--- a/views/stocks/partials/overview_hero.php
+++ b/views/stocks/partials/overview_hero.php
@@ -1,0 +1,79 @@
+<?php
+/** @var array $totals */
+/** @var array $chartMeta */
+/** @var array $portfolioChart */
+/** @var string $baseCurrency */
+/** @var array $marketByCurrency */
+/** @var string $preferredCurrency */
+/** @var float|null $preferredMarket */
+/** @var float|null $preferredUnrealized */
+?>
+<div class="relative flex flex-col gap-6 lg:flex-row lg:items-start">
+  <div class="flex-1 space-y-4">
+    <div>
+      <p class="text-xs uppercase tracking-widest text-white/60">Total value</p>
+      <div class="text-4xl font-semibold"><?= moneyfmt($totals['total_market_value'], $baseCurrency) ?></div>
+      <?php if ($preferredMarket !== null): ?>
+        <p class="text-sm text-white/70">≈ <?= moneyfmt($preferredMarket, $preferredCurrency) ?></p>
+      <?php endif; ?>
+    </div>
+    <div class="flex flex-wrap items-center gap-4 text-sm">
+      <div>
+        <span class="text-white/60">Change (<?= htmlspecialchars(strtoupper($chartMeta['range'])) ?>)</span>
+        <div class="text-lg font-medium <?= $chartMeta['change'] >= 0 ? 'text-emerald-300' : 'text-rose-300' ?>">
+          <?= ($chartMeta['change'] >= 0 ? '+' : '') . moneyfmt($chartMeta['change'], $baseCurrency) ?>
+          <span class="text-sm text-white/70">(<?= number_format($chartMeta['change_pct'], 2) ?>%)</span>
+        </div>
+      </div>
+      <div class="hidden sm:block h-10 w-px bg-white/10"></div>
+      <div>
+        <span class="text-white/60">Unrealized P/L</span>
+        <div class="text-lg font-medium <?= $totals['unrealized_pl'] >= 0 ? 'text-emerald-300' : 'text-rose-300' ?>">
+          <?= moneyfmt($totals['unrealized_pl'], $baseCurrency) ?>
+          <?php if ($preferredUnrealized !== null): ?>
+            <span class="text-sm text-white/70">(<?= moneyfmt($preferredUnrealized, $preferredCurrency) ?>)</span>
+          <?php endif; ?>
+        </div>
+      </div>
+    </div>
+    <?php if (!empty($marketByCurrency)): ?>
+      <div class="flex flex-wrap gap-3 text-xs text-white/70">
+        <?php foreach ($marketByCurrency as $currency => $amount): ?>
+          <span class="inline-flex items-center rounded-full bg-white/10 px-2.5 py-1 font-medium">
+            <?= htmlspecialchars($currency) ?> · <?= moneyfmt($amount, $currency) ?>
+          </span>
+        <?php endforeach; ?>
+      </div>
+    <?php endif; ?>
+  </div>
+  <div class="flex w-full flex-col gap-4 lg:w-1/2">
+    <div class="h-56">
+      <canvas id="portfolioValueChart" height="224"></canvas>
+    </div>
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <label class="inline-flex items-center gap-2 text-xs text-white/70">
+        <input type="checkbox" class="h-4 w-4 rounded border-white/40 bg-transparent text-emerald-300 focus:ring-emerald-200" data-role="chart-contributions" />
+        Show cash contributions
+      </label>
+      <form method="get" action="/stocks" class="flex flex-wrap gap-1" id="portfolioRangeForm">
+        <input type="hidden" name="q" value="<?= htmlspecialchars($filters['search'] ?? '') ?>" />
+        <input type="hidden" name="sector" value="<?= htmlspecialchars($filters['sector'] ?? '') ?>" />
+        <input type="hidden" name="currency" value="<?= htmlspecialchars($filters['currency'] ?? '') ?>" />
+        <input type="hidden" name="period" value="<?= htmlspecialchars($filters['realized_period'] ?? 'YTD') ?>" />
+        <?php if (!empty($filters['watchlist_only'])): ?>
+          <input type="hidden" name="watchlist" value="1" />
+        <?php endif; ?>
+        <?php foreach (['1M','3M','6M','1Y','5Y'] as $option): ?>
+          <?php $isActive = strtoupper($chartMeta['range']) === $option; ?>
+          <button
+            type="submit"
+            name="chartRange"
+            value="<?= htmlspecialchars($option) ?>"
+            class="px-3 py-1 text-xs font-medium rounded-full <?= $isActive ? 'bg-white text-slate-900 shadow-sm' : 'bg-white/10 text-white/80 hover:bg-white/20' ?>"
+            aria-pressed="<?= $isActive ? 'true' : 'false' ?>"
+          ><?= htmlspecialchars($option) ?></button>
+        <?php endforeach; ?>
+      </form>
+    </div>
+  </div>
+</div>

--- a/views/stocks/show.php
+++ b/views/stocks/show.php
@@ -164,7 +164,7 @@ $signals = $insights['signals'] ?? [];
   </section>
 </section>
 
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-lY+UZiVRbnlM1c01qmPvvrLpzjAU6YewsGmmKzBSSMSmc5QwDFi1Cdm42Hcps225" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous"></script>
 <script>
 (function(){
   const initialPriceHistory = <?= json_encode($priceHistory) ?>;

--- a/views/stocks/show.php
+++ b/views/stocks/show.php
@@ -200,7 +200,7 @@ $signals = $insights['signals'] ?? [];
   </section>
 </section>
 
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
 <script>
 (function(){
   const initialPriceHistory = <?= json_encode($priceHistory) ?>;

--- a/views/stocks/show.php
+++ b/views/stocks/show.php
@@ -1,0 +1,360 @@
+<?php
+/** @var array $stock */
+/** @var array|null $position */
+/** @var array|null $quote */
+/** @var array $priceHistory */
+/** @var array $insights */
+/** @var array $positionSeries */
+/** @var float $realizedYtd */
+/** @var array $settings */
+/** @var bool $isWatched */
+/** @var string $historyRange */
+/** @var string $baseCurrency */
+
+$rangeOptions = ['1D', '5D', '1M', '6M', '1Y', '5Y'];
+
+$symbol = $stock['symbol'];
+$currency = $stock['currency'] ?? 'USD';
+$lastPrice = $quote['last'] ?? null;
+$prevClose = $quote['prev_close'] ?? null;
+$change = ($lastPrice !== null && $prevClose !== null) ? $lastPrice - $prevClose : null;
+$changePct = ($change !== null && $prevClose) ? ($change / $prevClose) * 100 : null;
+$suggestions = $insights['suggestions'] ?? [];
+$signals = $insights['signals'] ?? [];
+?>
+
+<section class="space-y-6">
+  <header class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+    <div>
+      <h1 class="text-3xl font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+        <?= htmlspecialchars($symbol) ?>
+        <?php if (!empty($stock['name'])): ?>
+          <span class="text-base text-gray-500 font-normal"><?= htmlspecialchars($stock['name']) ?></span>
+        <?php endif; ?>
+      </h1>
+      <p class="text-sm text-gray-500 flex flex-wrap gap-3">
+        <?php if (!empty($stock['exchange'])): ?><span><?= htmlspecialchars($stock['exchange']) ?></span><?php endif; ?>
+        <span><?= htmlspecialchars($currency) ?></span>
+        <?php if (!empty($stock['sector'])): ?><span><?= htmlspecialchars($stock['sector']) ?></span><?php endif; ?>
+        <?php if (!empty($stock['industry'])): ?><span><?= htmlspecialchars($stock['industry']) ?></span><?php endif; ?>
+        <?php if (!empty($stock['beta'])): ?><span>β <?= number_format($stock['beta'], 2) ?></span><?php endif; ?>
+      </p>
+    </div>
+    <form method="post" action="/stocks/<?= urlencode($symbol) ?>/watch" class="flex items-center gap-3">
+      <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+      <button class="btn <?= $isWatched ? 'btn-secondary' : 'btn-primary' ?>">
+        <?= $isWatched ? 'Remove from watchlist' : 'Add to watchlist' ?>
+      </button>
+      <a href="/stocks" class="btn btn-ghost">Back to overview</a>
+    </form>
+  </header>
+
+  <section class="grid lg:grid-cols-3 gap-6">
+    <article class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40" id="positionCard"
+      data-qty="<?= $position ? htmlspecialchars($position['qty']) : 0 ?>"
+      data-avg="<?= $position ? htmlspecialchars($position['avg_cost_ccy']) : 0 ?>">
+      <h2 class="text-lg font-semibold mb-3">Live price</h2>
+      <div class="flex items-end gap-4">
+        <div>
+          <div class="text-4xl font-semibold text-gray-900 dark:text-gray-100" id="quoteLast">
+            <?= $lastPrice !== null ? moneyfmt($lastPrice, $currency) : '—' ?>
+          </div>
+          <div class="text-sm <?= ($change ?? 0) >= 0 ? 'text-emerald-500' : 'text-rose-500' ?>" id="quoteChange">
+            <?php if ($change !== null): ?>
+              <?= ($change >= 0 ? '+' : '') . moneyfmt($change, $currency) ?> (<?= number_format($changePct, 2) ?>%)
+            <?php else: ?>
+              —
+            <?php endif; ?>
+          </div>
+        </div>
+        <dl class="text-xs text-gray-500 space-y-1">
+          <div><dt class="uppercase tracking-wide">Prev Close</dt><dd id="quotePrev"><?= $prevClose !== null ? moneyfmt($prevClose, $currency) : '—' ?></dd></div>
+          <div><dt class="uppercase tracking-wide">Day High</dt><dd id="quoteHigh"><?= $quote['day_high'] ?? null ? moneyfmt($quote['day_high'], $currency) : '—' ?></dd></div>
+          <div><dt class="uppercase tracking-wide">Day Low</dt><dd id="quoteLow"><?= $quote['day_low'] ?? null ? moneyfmt($quote['day_low'], $currency) : '—' ?></dd></div>
+          <div><dt class="uppercase tracking-wide">Volume</dt><dd id="quoteVol"><?= $quote['volume'] ?? null ? number_format($quote['volume']) : '—' ?></dd></div>
+        </dl>
+      </div>
+      <p class="text-xs text-gray-400 mt-3">Refreshes every <?= (int)$settings['refresh_seconds'] ?: 10 ?>s</p>
+    </article>
+
+    <article class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
+      <h2 class="text-lg font-semibold mb-3">Position</h2>
+      <?php if ($position): ?>
+        <dl class="grid grid-cols-2 gap-3 text-sm">
+          <div><dt class="text-gray-500">Quantity</dt><dd class="text-gray-900 dark:text-gray-100"><?= number_format($position['qty'], 4) ?></dd></div>
+          <div><dt class="text-gray-500">Average cost</dt><dd><?= moneyfmt($position['avg_cost_ccy'], $currency) ?></dd></div>
+          <div><dt class="text-gray-500">Market value</dt><dd id="positionValue" data-currency="<?= htmlspecialchars($currency) ?>"><?= moneyfmt($position['qty'] * ($lastPrice ?? $position['avg_cost_ccy']), $currency) ?></dd></div>
+          <div><dt class="text-gray-500">Unrealized P/L</dt><dd id="positionUnrealized" data-currency="<?= htmlspecialchars($currency) ?>"><?= moneyfmt(($lastPrice !== null ? ($lastPrice - $position['avg_cost_ccy']) : 0) * $position['qty'], $currency) ?></dd></div>
+          <div><dt class="text-gray-500">Realized P/L (YTD)</dt><dd><?= moneyfmt($realizedYtd, $baseCurrency) ?></dd></div>
+          <div><dt class="text-gray-500">Cost basis method</dt><dd><?= htmlspecialchars($settings['unrealized_method'] ?? 'Average') ?></dd></div>
+        </dl>
+      <?php else: ?>
+        <p class="text-sm text-gray-500">No open position. Use the trade form to start tracking shares.</p>
+      <?php endif; ?>
+    </article>
+
+    <article class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
+      <h2 class="text-lg font-semibold mb-3">Insights</h2>
+      <?php if (!empty($suggestions)): ?>
+        <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-200">
+          <?php foreach ($suggestions as $suggestion): ?>
+            <li class="flex items-start gap-2"><span class="mt-1 h-2 w-2 rounded-full bg-emerald-400"></span><span><?= htmlspecialchars($suggestion) ?></span></li>
+          <?php endforeach; ?>
+        </ul>
+      <?php else: ?>
+        <p class="text-sm text-gray-500">No actionable suggestions. Position looks balanced.</p>
+      <?php endif; ?>
+      <?php if (!empty($signals)): ?>
+        <hr class="my-4 border-gray-200/70 dark:border-gray-800">
+        <ul class="text-xs text-gray-500 space-y-1">
+          <?php foreach ($signals as $signal): ?>
+            <li><strong><?= htmlspecialchars($signal['label']) ?>:</strong> <?= htmlspecialchars($signal['value']) ?></li>
+          <?php endforeach; ?>
+        </ul>
+      <?php endif; ?>
+    </article>
+  </section>
+
+  <section class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+      <h2 class="text-lg font-semibold">Price history</h2>
+      <form id="rangeForm" method="get" class="flex items-center gap-1" aria-label="Select price history range">
+        <input type="hidden" name="range" value="<?= htmlspecialchars($historyRange) ?>" />
+        <div role="radiogroup" class="flex flex-wrap gap-1">
+          <?php foreach ($rangeOptions as $option): ?>
+            <?php $isActive = strtoupper($historyRange) === $option; ?>
+            <button
+              type="submit"
+              name="range"
+              value="<?= htmlspecialchars($option) ?>"
+              data-range-btn="<?= htmlspecialchars($option) ?>"
+              class="btn <?= $isActive ? 'btn-primary' : 'btn-ghost' ?> px-3 py-1 text-sm"
+              aria-pressed="<?= $isActive ? 'true' : 'false' ?>"
+            ><?= htmlspecialchars($option) ?></button>
+          <?php endforeach; ?>
+        </div>
+      </form>
+    </div>
+    <canvas id="priceHistoryChart" height="240"></canvas>
+  </section>
+
+  <section class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
+    <h2 class="text-lg font-semibold mb-4">Position value</h2>
+    <canvas id="positionValueChart" height="220"></canvas>
+  </section>
+
+  <section class="card p-5 shadow-md bg-white/80 dark:bg-gray-900/40">
+    <h2 class="text-lg font-semibold mb-3">Quick trade</h2>
+    <form method="post" action="/stocks/trade" class="grid sm:grid-cols-6 gap-3">
+      <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+      <input type="hidden" name="symbol" value="<?= htmlspecialchars($symbol) ?>" />
+      <select name="side" class="input">
+        <option value="BUY">Buy</option>
+        <option value="SELL">Sell</option>
+      </select>
+      <input name="quantity" type="number" step="0.0001" placeholder="Qty" class="input" required />
+      <input name="price" type="number" step="0.0001" value="<?= $lastPrice !== null ? htmlspecialchars($lastPrice) : '' ?>" placeholder="Price" class="input" required />
+      <input name="currency" value="<?= htmlspecialchars($currency) ?>" class="input" />
+      <input name="fee" type="number" step="0.01" placeholder="Fee" class="input" />
+      <input name="trade_date" type="date" value="<?= date('Y-m-d') ?>" class="input" />
+      <input name="trade_time" type="time" value="<?= date('H:i') ?>" class="input" />
+      <input name="note" placeholder="Note" class="input sm:col-span-2" />
+      <button class="btn btn-primary sm:col-span-2">Submit trade</button>
+    </form>
+  </section>
+</section>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-lY+UZiVRbnlM1c01qmPvvrLpzjAU6YewsGmmKzBSSMSmc5QwDFi1Cdm42Hcps225" crossorigin="anonymous"></script>
+<script>
+(function(){
+  const initialPriceHistory = <?= json_encode($priceHistory) ?>;
+  const initialPositionSeries = <?= json_encode($positionSeries) ?>;
+  const symbol = <?= json_encode($symbol) ?>;
+  const refreshMs = (<?= (int)($settings['refresh_seconds'] ?? 10) ?>) * 1000;
+  const currency = <?= json_encode($currency) ?>;
+  const initialRange = <?= json_encode(strtoupper($historyRange)) ?>;
+
+  const rangeForm = document.getElementById('rangeForm');
+  const rangeButtons = rangeForm ? Array.from(rangeForm.querySelectorAll('[data-range-btn]')) : [];
+  const rangeHidden = rangeForm ? rangeForm.querySelector('input[name="range"]') : null;
+
+  const priceCtx = document.getElementById('priceHistoryChart');
+  let priceChart = null;
+  function ensurePriceChart(data) {
+    if (!priceCtx) {
+      return;
+    }
+    const labels = (data || []).map(item => item.date);
+    const closes = (data || []).map(item => item.close);
+    if (!priceChart) {
+      priceChart = new Chart(priceCtx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [{
+            data: closes,
+            borderColor: '#60a5fa',
+            tension: 0.3,
+            fill: true,
+            pointRadius: 0,
+            backgroundColor: 'rgba(96, 165, 250, 0.15)'
+          }]
+        },
+        options: {
+          plugins: { legend: { display: false } },
+          scales: { x: { display: false } },
+        }
+      });
+    } else {
+      priceChart.data.labels = labels;
+      priceChart.data.datasets[0].data = closes;
+      priceChart.update();
+    }
+  }
+
+  const positionCtx = document.getElementById('positionValueChart');
+  let positionChart = null;
+  function ensurePositionChart(series) {
+    if (!positionCtx) {
+      return;
+    }
+    const labels = (series && Array.isArray(series.labels)) ? series.labels : [];
+    const values = (series && Array.isArray(series.series)) ? series.series : [];
+    if (!positionChart) {
+      positionChart = new Chart(positionCtx, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [{
+            data: values,
+            borderColor: '#34d399',
+            backgroundColor: 'rgba(52, 211, 153, 0.15)',
+            fill: true,
+            tension: 0.3,
+            spanGaps: true,
+            pointRadius: 0,
+          }]
+        },
+        options: { plugins: { legend: { display: false } }, scales: { x: { display: false } } }
+      });
+    } else {
+      positionChart.data.labels = labels;
+      positionChart.data.datasets[0].data = values;
+      positionChart.update();
+    }
+  }
+
+  function setActiveRange(range) {
+    const upper = (range || '').toUpperCase();
+    rangeButtons.forEach(btn => {
+      const active = btn.dataset.rangeBtn === upper;
+      btn.classList.toggle('btn-primary', active);
+      btn.classList.toggle('btn-ghost', !active);
+      btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
+    if (rangeHidden) {
+      rangeHidden.value = upper;
+    }
+  }
+
+  ensurePriceChart(initialPriceHistory);
+  ensurePositionChart(initialPositionSeries);
+  setActiveRange(initialRange);
+
+  async function loadRange(range) {
+    if (!rangeForm) {
+      return;
+    }
+    rangeForm.classList.add('opacity-60', 'pointer-events-none');
+    try {
+      const resp = await fetch(`/api/stocks/${encodeURIComponent(symbol)}/history?range=${encodeURIComponent(range)}`);
+      if (!resp.ok) {
+        throw new Error(`History request failed (${resp.status})`);
+      }
+      const payload = await resp.json();
+      if (payload && payload.price) {
+        ensurePriceChart(payload.price);
+      }
+      if (payload && payload.position) {
+        ensurePositionChart(payload.position);
+      }
+    } finally {
+      rangeForm.classList.remove('opacity-60', 'pointer-events-none');
+    }
+  }
+
+  if (rangeForm) {
+    rangeForm.addEventListener('submit', function(evt) {
+      if (rangeForm.dataset.forceSubmit === '1') {
+        return;
+      }
+      const submitter = evt.submitter;
+      if (submitter && submitter.dataset.rangeBtn) {
+        evt.preventDefault();
+        const selected = submitter.dataset.rangeBtn;
+        setActiveRange(selected);
+        loadRange(selected).catch(() => {
+          rangeForm.dataset.forceSubmit = '1';
+          rangeForm.submit();
+        });
+      }
+    });
+  }
+
+  async function refreshQuote(){
+    try {
+      const resp = await fetch(`/api/stocks/live?symbols=${symbol}`);
+      if (!resp.ok) return;
+      const data = await resp.json();
+      if (!data || !data.quotes || !data.quotes.length) return;
+      const quote = data.quotes[0];
+      const formatter = new Intl.NumberFormat(undefined, { style: 'currency', currency: quote.currency || currency });
+      if (quote.last !== null) {
+        document.getElementById('quoteLast').textContent = formatter.format(quote.last);
+        const card = document.getElementById('positionCard');
+        if (card) {
+          const qty = parseFloat(card.dataset.qty || '0');
+          const avg = parseFloat(card.dataset.avg || '0');
+          const valueEl = document.getElementById('positionValue');
+          const unrealizedEl = document.getElementById('positionUnrealized');
+          if (valueEl) {
+            valueEl.textContent = formatter.format(qty * quote.last);
+          }
+          if (unrealizedEl) {
+            const diff = (quote.last - avg) * qty;
+            unrealizedEl.textContent = formatter.format(diff);
+            unrealizedEl.classList.toggle('text-emerald-500', diff >= 0);
+            unrealizedEl.classList.toggle('text-rose-500', diff < 0);
+          }
+        }
+      }
+      if (quote.prev_close !== null && quote.last !== null) {
+        const diff = quote.last - quote.prev_close;
+        const pct = quote.prev_close ? (diff / quote.prev_close) * 100 : 0;
+        const text = `${diff >= 0 ? '+' : ''}${formatter.format(diff)} (${pct.toFixed(2)}%)`;
+        const changeEl = document.getElementById('quoteChange');
+        changeEl.textContent = text;
+        changeEl.classList.toggle('text-emerald-500', diff >= 0);
+        changeEl.classList.toggle('text-rose-500', diff < 0);
+      }
+      if (quote.prev_close !== null) document.getElementById('quotePrev').textContent = formatter.format(quote.prev_close);
+      if (quote.day_high !== null) document.getElementById('quoteHigh').textContent = formatter.format(quote.day_high);
+      if (quote.day_low !== null) document.getElementById('quoteLow').textContent = formatter.format(quote.day_low);
+      if (quote.volume !== null) document.getElementById('quoteVol').textContent = new Intl.NumberFormat().format(quote.volume);
+    } catch (err) {
+      console.warn('Quote refresh failed', err);
+    }
+  }
+
+  refreshQuote();
+  let timer = setInterval(refreshQuote, refreshMs);
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      clearInterval(timer);
+    } else {
+      refreshQuote();
+      timer = setInterval(refreshQuote, refreshMs);
+    }
+  });
+})();
+</script>

--- a/views/stocks/transactions.php
+++ b/views/stocks/transactions.php
@@ -1,0 +1,90 @@
+<?php
+/** @var array $transactions */
+/** @var string $baseCurrency */
+
+$formatQuantity = static function ($qty): string {
+    $formatted = number_format((float)$qty, 6, '.', '');
+    $trimmed = rtrim(rtrim($formatted, '0'), '.');
+    return $trimmed === '' ? '0' : $trimmed;
+};
+?>
+
+<section class="space-y-6">
+  <header class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <div>
+      <h1 class="text-3xl font-semibold text-gray-900 dark:text-gray-100">Transactions</h1>
+      <p class="text-sm text-gray-500">A chronological ledger of every equity trade recorded for your account.</p>
+    </div>
+    <a href="/stocks" class="btn btn-ghost">Back to overview</a>
+  </header>
+
+  <article class="rounded-2xl border border-gray-200/70 bg-white/80 p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/40">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">All transactions</h2>
+        <p class="text-xs text-gray-500">Newest orders first, including fractional quantities and legacy imports.</p>
+      </div>
+      <span class="text-xs text-gray-400">Total: <?= count($transactions) ?></span>
+    </div>
+    <div class="mt-4 overflow-x-auto">
+      <table class="min-w-full text-sm">
+        <thead class="bg-gray-50/80 text-gray-600 uppercase text-xs tracking-wide dark:bg-gray-900/60">
+          <tr>
+            <th class="px-5 py-3 text-left">Date</th>
+            <th class="px-5 py-3 text-left">Ticker</th>
+            <th class="px-5 py-3 text-left">Side</th>
+            <th class="px-5 py-3 text-right">Quantity</th>
+            <th class="px-5 py-3 text-right">Price</th>
+            <th class="px-5 py-3 text-right">Fee</th>
+            <th class="px-5 py-3 text-right">Total</th>
+            <th class="px-5 py-3 text-left">Note</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+          <?php if (empty($transactions)): ?>
+            <tr>
+              <td colspan="8" class="px-5 py-8 text-center text-gray-500">No trades recorded yet.</td>
+            </tr>
+          <?php endif; ?>
+          <?php foreach ($transactions as $trade):
+            $executedAt = $trade['executed_at'] ?? null;
+            $tradeOn = $trade['trade_on'] ?? null;
+            $timestamp = $executedAt ?: $tradeOn;
+            $displayDate = $timestamp ? date('Y-m-d H:i', strtotime($timestamp)) : '—';
+            $side = strtoupper((string)($trade['side'] ?? ''));
+            $quantityDisplay = $formatQuantity($trade['quantity'] ?? 0);
+            $currency = $trade['currency'] ?? ($trade['stock_currency'] ?? $baseCurrency);
+            $priceDisplay = moneyfmt((float)($trade['price'] ?? 0), $currency);
+            $feeAmount = (float)($trade['fee'] ?? 0);
+            $feeDisplay = $feeAmount !== 0.0 ? moneyfmt($feeAmount, $currency) : '—';
+            $total = (float)($trade['quantity'] ?? 0) * (float)($trade['price'] ?? 0);
+            $totalDisplay = moneyfmt($total, $currency);
+            $note = $trade['note'] ?? '';
+          ?>
+            <tr>
+              <td class="px-5 py-4 whitespace-nowrap text-gray-600 dark:text-gray-300"><?= htmlspecialchars($displayDate) ?></td>
+              <td class="px-5 py-4 font-semibold text-gray-900 dark:text-gray-100">
+                <?= htmlspecialchars($trade['symbol'] ?? '') ?>
+                <?php if (!empty($trade['name'])): ?>
+                  <span class="block text-xs text-gray-500"><?= htmlspecialchars($trade['name']) ?></span>
+                <?php endif; ?>
+              </td>
+              <td class="px-5 py-4">
+                <span class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium <?= $side === 'BUY' ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200' : 'bg-rose-100 text-rose-700 dark:bg-rose-500/20 dark:text-rose-200' ?>">
+                  <?= htmlspecialchars($side) ?>
+                </span>
+              </td>
+              <td class="px-5 py-4 text-right font-mono text-xs sm:text-sm"><?= htmlspecialchars($quantityDisplay) ?></td>
+              <td class="px-5 py-4 text-right"><?= $priceDisplay ?></td>
+              <td class="px-5 py-4 text-right"><?= $feeDisplay ?></td>
+              <td class="px-5 py-4 text-right"><?= $totalDisplay ?></td>
+              <td class="px-5 py-4 text-left text-xs text-gray-500">
+                <?= $note !== '' ? htmlspecialchars($note) : '—' ?>
+              </td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+  </article>
+</section>


### PR DESCRIPTION
## Summary
- add normalized schema and migrations for stocks, lots, realized P/L, pricing caches, and watchlists
- implement pricing, portfolio, trade, signals, and charts services with controller routing updates and live quote polling
- redesign /stocks overview and detail pages, add helper CLI scripts, docs, and regression tests

## Testing
- php -l src/stocks/TradeService.php
- php -l views/stocks/index.php
- php tests/stocks/trade_service_test.php *(skipped: database unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68dcba06d1cc83299d9501ed6b7c2fad