### PR TITLE
Add EF transaction link column

### DIFF
--- a/migrations/021_emergency_fund_tx_link.sql
+++ b/migrations/021_emergency_fund_tx_link.sql
@@ -1,0 +1,7 @@
+-- ensure transactions can link back to emergency fund entries
+ALTER TABLE transactions
+  ADD COLUMN IF NOT EXISTS ef_tx_id bigint;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_ef_tx_id
+  ON transactions(ef_tx_id)
+  WHERE ef_tx_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- add a migration that adds the `ef_tx_id` column to the `transactions` table
- ensure the new column is indexed for efficient lookups

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68decd243c948329a68ddbde1d3a9fb9