### PR TITLE
Process goal and loan updates from scheduled payments

### DIFF
--- a/index.php
+++ b/index.php
@@ -30,9 +30,14 @@ require $root . '/src/helpers.php';
 require $root . '/src/auth.php';
 require $root . '/src/webauthn.php';
 require $root . '/src/fx.php';
+require $root . '/src/scheduled_runner.php';
 
 if (isset($pdo) && $pdo instanceof PDO) {
     attempt_remembered_login($pdo);
+}
+
+if (isset($pdo) && $pdo instanceof PDO && is_logged_in()) {
+    scheduled_process_linked($pdo, uid());
 }
 
 $rawPath = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';

--- a/src/scheduled_runner.php
+++ b/src/scheduled_runner.php
@@ -1,0 +1,217 @@
+<?php
+// src/scheduled_runner.php
+
+require_once __DIR__ . '/recurrence.php';
+require_once __DIR__ . '/helpers.php';
+
+/**
+ * Compute the next occurrence of a schedule after a given date.
+ */
+function scheduled_next_occurrence(?string $dtstart, string $rrule, string $afterDate): ?string {
+  if (!$dtstart) {
+    return null;
+  }
+
+  $after = new DateTimeImmutable($afterDate);
+  $rangeStart = $after->modify('+1 day')->format('Y-m-d');
+  $rangeEnd   = $after->modify('+10 years')->format('Y-m-d');
+  $dates = rrule_expand($dtstart, $rrule, $rangeStart, $rangeEnd);
+  return $dates[0] ?? null;
+}
+
+function scheduled_build_rrule(array $parts): string {
+  $items = [];
+  if (!empty($parts['FREQ'])) {
+    $items[] = 'FREQ=' . $parts['FREQ'];
+  }
+  if (!empty($parts['INTERVAL']) && (int)$parts['INTERVAL'] !== 1) {
+    $items[] = 'INTERVAL=' . (int)$parts['INTERVAL'];
+  }
+  if (!empty($parts['BYDAY'])) {
+    $items[] = 'BYDAY=' . implode(',', array_map('strtoupper', $parts['BYDAY']));
+  }
+  if (array_key_exists('BYMONTHDAY', $parts) && $parts['BYMONTHDAY'] !== null) {
+    $items[] = 'BYMONTHDAY=' . (int)$parts['BYMONTHDAY'];
+  }
+  if (array_key_exists('BYMONTH', $parts) && $parts['BYMONTH'] !== null) {
+    $items[] = 'BYMONTH=' . (int)$parts['BYMONTH'];
+  }
+  if (!empty($parts['UNTIL'])) {
+    $items[] = 'UNTIL=' . $parts['UNTIL'];
+  }
+  if (array_key_exists('COUNT', $parts) && $parts['COUNT'] !== null && (int)$parts['COUNT'] > 0) {
+    $items[] = 'COUNT=' . (int)$parts['COUNT'];
+  }
+  return implode(';', $items);
+}
+
+/**
+ * Apply scheduled payments linked to goals.
+ */
+function scheduled_apply_goal(PDO $pdo, array $schedule, string $dueDate): void {
+  $goalId = (int)($schedule['goal_id'] ?? 0);
+  if (!$goalId) {
+    return;
+  }
+
+  $u = (int)($schedule['user_id'] ?? 0);
+  $goalStmt = $pdo->prepare('SELECT id, user_id, currency FROM goals WHERE id=? AND user_id=?');
+  $goalStmt->execute([$goalId, $u]);
+  $goal = $goalStmt->fetch(PDO::FETCH_ASSOC);
+  if (!$goal) {
+    return;
+  }
+
+  $amount = (float)($schedule['amount'] ?? 0);
+  if ($amount <= 0) {
+    return;
+  }
+
+  $currency = strtoupper($schedule['currency'] ?? '');
+  if ($currency === '') {
+    $currency = $goal['currency'] ?: 'HUF';
+  }
+
+  $note = 'Scheduled: ' . trim((string)($schedule['title'] ?? 'Goal contribution'));
+
+  $ins = $pdo->prepare('INSERT INTO goal_contributions(goal_id,user_id,amount,currency,occurred_on,note) VALUES (?,?,?,?,?,?)');
+  $ins->execute([$goalId, $u, $amount, $currency, $dueDate, $note]);
+
+  $goalCurrency = $goal['currency'] ?: $currency;
+  if ($currency === $goalCurrency) {
+    $delta = $amount;
+  } else {
+    $converted = function_exists('fx_convert')
+      ? fx_convert($pdo, $amount, $currency, $goalCurrency, $dueDate)
+      : null;
+    $delta = is_numeric($converted) ? (float)$converted : $amount;
+  }
+
+  $upd = $pdo->prepare('UPDATE goals SET current_amount = COALESCE(current_amount,0) + ?, currency = COALESCE(currency, ?) WHERE id=? AND user_id=?');
+  $upd->execute([$delta, $goalCurrency, $goalId, $u]);
+}
+
+/**
+ * Apply scheduled payments linked to loans.
+ */
+function scheduled_apply_loan(PDO $pdo, array $schedule, string $dueDate): void {
+  $loanId = (int)($schedule['loan_id'] ?? 0);
+  if (!$loanId) {
+    return;
+  }
+
+  $u = (int)($schedule['user_id'] ?? 0);
+  $loanStmt = $pdo->prepare('SELECT id, user_id, currency FROM loans WHERE id=? AND user_id=?');
+  $loanStmt->execute([$loanId, $u]);
+  $loan = $loanStmt->fetch(PDO::FETCH_ASSOC);
+  if (!$loan) {
+    return;
+  }
+
+  $amount = (float)($schedule['amount'] ?? 0);
+  if ($amount <= 0) {
+    return;
+  }
+
+  $currency = strtoupper($schedule['currency'] ?? '');
+  if ($currency === '') {
+    $currency = $loan['currency'] ?: 'HUF';
+  }
+
+  $ins = $pdo->prepare('INSERT INTO loan_payments(loan_id,paid_on,amount,principal_component,interest_component,currency) VALUES (?,?,?,?,?,?)');
+  $ins->execute([$loanId, $dueDate, $amount, $amount, 0.0, $currency]);
+
+  $loanCurrency = $loan['currency'] ?: $currency;
+  if ($currency === $loanCurrency) {
+    $principalDelta = $amount;
+  } else {
+    $converted = function_exists('fx_convert')
+      ? fx_convert($pdo, $amount, $currency, $loanCurrency, $dueDate)
+      : null;
+    $principalDelta = is_numeric($converted) ? (float)$converted : $amount;
+  }
+
+  $pdo->prepare('UPDATE loans SET balance = GREATEST(0, balance - ?) WHERE id=? AND user_id=?')->execute([$principalDelta, $loanId, $u]);
+}
+
+/**
+ * Process due scheduled payments linked to goals or loans for the given user.
+ */
+function scheduled_process_linked(PDO $pdo, int $userId, ?string $today = null): void {
+  if ($userId <= 0) {
+    return;
+  }
+
+  $today = $today ?: date('Y-m-d');
+
+  $listStmt = $pdo->prepare('SELECT id FROM scheduled_payments WHERE user_id=? AND next_due IS NOT NULL AND next_due <= ? AND (goal_id IS NOT NULL OR loan_id IS NOT NULL) ORDER BY next_due, id');
+  $listStmt->execute([$userId, $today]);
+  $ids = $listStmt->fetchAll(PDO::FETCH_COLUMN);
+
+  foreach ($ids as $id) {
+    $pdo->beginTransaction();
+    try {
+      $rowStmt = $pdo->prepare('SELECT * FROM scheduled_payments WHERE id=? AND user_id=? FOR UPDATE');
+      $rowStmt->execute([(int)$id, $userId]);
+      $schedule = $rowStmt->fetch(PDO::FETCH_ASSOC);
+      if (!$schedule) {
+        $pdo->commit();
+        continue;
+      }
+
+      $due = $schedule['next_due'] ?? null;
+      if (!$due || $due > $today) {
+        $pdo->commit();
+        continue;
+      }
+
+      $rruleString = (string)($schedule['rrule'] ?? '');
+      $rruleParts  = rrule_parse($rruleString);
+      $countRemaining = $rruleParts['COUNT'];
+
+      while ($due !== null && $due <= $today) {
+        if (!empty($schedule['goal_id'])) {
+          scheduled_apply_goal($pdo, $schedule, $due);
+        }
+        if (!empty($schedule['loan_id'])) {
+          scheduled_apply_loan($pdo, $schedule, $due);
+        }
+
+        $processedDue = $schedule['next_due'];
+
+        if ($countRemaining !== null) {
+          $countRemaining--;
+          if ($countRemaining <= 0) {
+            $rruleParts['COUNT'] = null;
+            $rruleString = scheduled_build_rrule($rruleParts);
+            $schedule['rrule'] = $rruleString;
+            $schedule['next_due'] = null;
+            $due = null;
+            break;
+          }
+          $rruleParts['COUNT'] = $countRemaining;
+          $rruleString = scheduled_build_rrule($rruleParts);
+          $schedule['rrule'] = $rruleString;
+        }
+
+        $next = scheduled_next_occurrence($processedDue, $rruleString, $processedDue);
+        if ($next !== null && $next <= $processedDue) {
+          $schedule['next_due'] = null;
+          $due = null;
+          break;
+        }
+
+        $schedule['next_due'] = $next;
+        $due = $next;
+      }
+
+      $upd = $pdo->prepare('UPDATE scheduled_payments SET next_due=?, rrule=? WHERE id=? AND user_id=?');
+      $upd->execute([$schedule['next_due'], $schedule['rrule'], (int)$id, $userId]);
+
+      $pdo->commit();
+    } catch (Throwable $e) {
+      $pdo->rollBack();
+      // Optionally log in the future.
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a scheduled runner that credits goals and records loan payments when linked schedules reach their due date
- advance schedule recurrence metadata while respecting RRULE COUNT values and updating next due dates
- invoke the runner during request bootstrap so linked schedules are processed automatically after login

## Testing
- php -l index.php
- php -l src/scheduled_runner.php

------
https://chatgpt.com/codex/tasks/task_e_68dec8f102448329b699c06ccca430d6