### PR TITLE
Handle scheduled payments lacking next_due

### DIFF
--- a/src/controllers/emergency.php
+++ b/src/controllers/emergency.php
@@ -39,6 +39,11 @@ function emergency_index(PDO $pdo){
     $dtstart = $s['next_due'];       // DTSTART for the RRULE
     $rr = trim($s['rrule'] ?? '');
 
+    // Skip malformed schedules (no next_due or rule)
+    if (!$dtstart || !is_string($dtstart)) {
+      continue;
+    }
+
     // expand into the next month range
     $dates = rrule_expand($dtstart, $rr, $firstNext, $lastNext); // array of 'Y-m-d'
     if (!$dates || !count($dates)) continue;

--- a/src/controllers/month.php
+++ b/src/controllers/month.php
@@ -198,6 +198,11 @@ function month_show(PDO $pdo, ?int $year = null, ?int $month = null) {
     $dtstart = $s['next_due'];             // DTSTART
     $rr = trim($s['rrule'] ?? '');
 
+    // Skip malformed schedules (no next_due or rule)
+    if (!$dtstart || !is_string($dtstart)) {
+      continue;
+    }
+
     // Expand occurrences for current month window
     $dates = rrule_expand($dtstart, $rr, $first, $last); // returns array of 'Y-m-d'
     if (!$dates) continue;


### PR DESCRIPTION
## Summary
- skip expanding scheduled payments that do not have a next_due value to avoid null DTSTART errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded0ce649883298c2782c78d49b616