### PR TITLE
Add management UI for goal contributions and loan payments

### DIFF
--- a/index.php
+++ b/index.php
@@ -549,6 +549,12 @@ switch ($path) {
             goals_tx_add($pdo);
         }
         break;
+    case '/goals/tx/update':
+        if ($method === 'POST') {
+            require __DIR__ . '/src/controllers/goals.php';
+            goals_tx_update($pdo);
+        }
+        break;
     case '/goals/tx/delete':
         require __DIR__ . '/src/controllers/goals.php';
         goals_tx_delete($pdo);
@@ -582,6 +588,18 @@ switch ($path) {
         require_login();
         require __DIR__ . '/src/controllers/loans.php';
         if ($_SERVER['REQUEST_METHOD'] === 'POST') { loan_payment_add($pdo); }
+        redirect('/loans');
+        break;
+    case '/loans/payment/update':
+        require_login();
+        require __DIR__ . '/src/controllers/loans.php';
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') { loan_payment_update($pdo); }
+        redirect('/loans');
+        break;
+    case '/loans/payment/delete':
+        require_login();
+        require __DIR__ . '/src/controllers/loans.php';
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') { loan_payment_delete($pdo); }
         redirect('/loans');
         break;
     case '/loals/unlink-schedule':

--- a/views/goals/index.php
+++ b/views/goals/index.php
@@ -111,6 +111,10 @@
 
           <td class="py-3 pr-0 align-middle" style="text-align:right;">
             <div class="flex justify-end gap-2">
+              <button class="icon-action" data-open="#goal-history-<?= (int)$g['id'] ?>" title="<?= __('View history') ?>">
+                <i data-lucide="history" class="h-4 w-4"></i>
+                <span class="sr-only"><?= __('View history') ?></span>
+              </button>
               <button class="btn btn-primary !px-3"
                       data-open="#goal-add-<?= (int)$g['id'] ?>"><?= __('Add money') ?></button>
               <button class="btn !px-3"
@@ -145,10 +149,16 @@
             <div class="font-medium"><?= htmlspecialchars($g['title']) ?></div>
             <div class="text-xs text-gray-500"><?= $statusLabel ?> · <?= htmlspecialchars($cur) ?></div>
           </div>
-          <button class="icon-action icon-action--primary" data-open="#goal-edit-<?= (int)$g['id'] ?>" title="<?= __('Edit') ?>">
-            <i data-lucide="pencil" class="h-4 w-4"></i>
-            <span class="sr-only"><?= __('Edit') ?></span>
-          </button>
+          <div class="flex items-center gap-2">
+            <button class="icon-action" data-open="#goal-history-<?= (int)$g['id'] ?>" title="<?= __('View history') ?>">
+              <i data-lucide="history" class="h-4 w-4"></i>
+              <span class="sr-only"><?= __('View history') ?></span>
+            </button>
+            <button class="icon-action icon-action--primary" data-open="#goal-edit-<?= (int)$g['id'] ?>" title="<?= __('Edit') ?>">
+              <i data-lucide="pencil" class="h-4 w-4"></i>
+              <span class="sr-only"><?= __('Edit') ?></span>
+            </button>
+          </div>
         </div>
         <div class="mt-3">
           <div class="h-2 bg-brand-100/60 rounded-full">
@@ -472,56 +482,71 @@
         <button class="btn btn-primary" form="goal-add-form-<?= $goalId ?>"><?= __('Add money') ?></button>
       </div>
     </div>
+  </div>
+</div>
+<div id="goal-history-<?= $goalId ?>" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="goal-history-title-<?= $goalId ?>">
+  <div class="modal-backdrop" data-close></div>
 
-    <div class="px-6 pb-6">
-      <div class="mt-6">
-        <h4 class="font-semibold mb-3"><?= __('Transactions') ?></h4>
-        <?php if ($goalTxList): ?>
-          <div class="overflow-x-auto">
-            <table class="min-w-full text-sm">
-              <thead>
-                <tr class="text-left text-xs uppercase tracking-wide text-gray-500">
-                  <th class="py-2 pr-3"><?= __('Date') ?></th>
-                  <th class="py-2 pr-3"><?= __('Amount') ?></th>
-                  <th class="py-2 pr-3"><?= __('Note') ?></th>
-                  <th class="py-2 pr-0 text-right"><?= __('Actions') ?></th>
-                </tr>
-              </thead>
-              <tbody>
-              <?php foreach ($goalTxList as $tx): $txId=(int)$tx['id']; $txCur = $tx['currency'] ?: $cur; ?>
-                <tr class="border-t">
-                  <td class="py-2 pr-3 align-middle text-sm"><?= htmlspecialchars($tx['occurred_on']) ?></td>
-                  <td class="py-2 pr-3 align-middle text-sm">
-                    <?= moneyfmt((float)$tx['amount'], $txCur) ?>
-                    <?php if ($txCur && strtoupper($txCur) !== strtoupper($cur)): ?>
-                      <span class="text-xs text-gray-500">(<?= htmlspecialchars($txCur) ?>)</span>
-                    <?php endif; ?>
-                  </td>
-                  <td class="py-2 pr-3 align-middle text-sm">
-                    <?php if ($tx['note'] !== null && $tx['note'] !== ''): ?>
-                      <?= htmlspecialchars($tx['note']) ?>
-                    <?php else: ?>
-                      <span class="text-gray-400"><?= __('No note') ?></span>
-                    <?php endif; ?>
-                  </td>
-                  <td class="py-2 pr-0 align-middle text-right">
-                    <div class="flex justify-end gap-2">
-                      <button type="button" class="btn !px-3" data-open="#goal-tx-edit-<?= $txId ?>"><?= __('Edit') ?></button>
-                      <form method="post" action="/goals/tx/delete" onsubmit="return confirm('<?= __('Delete this transaction?') ?>');">
-                        <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
-                        <input type="hidden" name="id" value="<?= $txId ?>" />
-                        <button class="btn btn-danger !px-3" type="submit"><?= __('Delete') ?></button>
-                      </form>
-                    </div>
-                  </td>
-                </tr>
-              <?php endforeach; ?>
-              </tbody>
-            </table>
-          </div>
-        <?php else: ?>
-          <p class="text-sm text-gray-500"><?= __('No transactions yet.') ?></p>
-        <?php endif; ?>
+  <div class="modal-panel">
+    <div class="modal-header">
+      <h3 id="goal-history-title-<?= $goalId ?>" class="font-semibold"><?= __('Transactions') ?></h3>
+      <button type="button" class="icon-btn" aria-label="<?= __('Close') ?>" data-close>
+        <i data-lucide="x" class="h-5 w-5"></i>
+      </button>
+    </div>
+
+    <div class="modal-body">
+      <?php if ($goalTxList): ?>
+        <div class="overflow-x-auto">
+          <table class="min-w-full text-sm">
+            <thead>
+              <tr class="text-left text-xs uppercase tracking-wide text-gray-500">
+                <th class="py-2 pr-3"><?= __('Date') ?></th>
+                <th class="py-2 pr-3"><?= __('Amount') ?></th>
+                <th class="py-2 pr-3"><?= __('Note') ?></th>
+                <th class="py-2 pr-0 text-right"><?= __('Actions') ?></th>
+              </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($goalTxList as $tx): $txId=(int)$tx['id']; $txCur = $tx['currency'] ?: $cur; ?>
+              <tr class="border-t">
+                <td class="py-2 pr-3 align-middle text-sm"><?= htmlspecialchars($tx['occurred_on']) ?></td>
+                <td class="py-2 pr-3 align-middle text-sm">
+                  <?= moneyfmt((float)$tx['amount'], $txCur) ?>
+                  <?php if ($txCur && strtoupper($txCur) !== strtoupper($cur)): ?>
+                    <span class="text-xs text-gray-500">(<?= htmlspecialchars($txCur) ?>)</span>
+                  <?php endif; ?>
+                </td>
+                <td class="py-2 pr-3 align-middle text-sm">
+                  <?php if ($tx['note'] !== null && $tx['note'] !== ''): ?>
+                    <?= htmlspecialchars($tx['note']) ?>
+                  <?php else: ?>
+                    <span class="text-gray-400"><?= __('No note') ?></span>
+                  <?php endif; ?>
+                </td>
+                <td class="py-2 pr-0 align-middle text-right">
+                  <div class="flex justify-end gap-2">
+                    <button type="button" class="btn !px-3" data-open="#goal-tx-edit-<?= $txId ?>"><?= __('Edit') ?></button>
+                    <form method="post" action="/goals/tx/delete" onsubmit="return confirm('<?= __('Delete this transaction?') ?>');">
+                      <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+                      <input type="hidden" name="id" value="<?= $txId ?>" />
+                      <button class="btn btn-danger !px-3" type="submit"><?= __('Delete') ?></button>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+      <?php else: ?>
+        <p class="text-sm text-gray-500"><?= __('No transactions yet.') ?></p>
+      <?php endif; ?>
+    </div>
+
+    <div class="modal-footer">
+      <div class="flex justify-end">
+        <button type="button" class="btn" data-close><?= __('Close') ?></button>
       </div>
     </div>
   </div>

--- a/views/loans/index.php
+++ b/views/loans/index.php
@@ -241,6 +241,10 @@
 
           <td class="py-3 pr-3 text-right align-middle">
             <div class="flex justify-end gap-2">
+              <button class="icon-action" data-open="#loan-history-<?= (int)$l['id'] ?>" title="<?= __('View history') ?>">
+                <i data-lucide="history" class="h-4 w-4"></i>
+                <span class="sr-only"><?= __('View history') ?></span>
+              </button>
               <button type="button"
                       class="btn btn-primary !px-3"
                       data-open="#loan-pay-<?= (int)$l['id'] ?>">
@@ -276,10 +280,16 @@
             <div class="font-medium"><?= htmlspecialchars($l['name']) ?></div>
             <div class="text-xs text-gray-500"><?= __('APR :rate%', ['rate' => (float)$l['interest_rate']]) ?></div>
           </div>
-          <button type="button" class="icon-action icon-action--primary" data-open="#loan-edit-<?= (int)$l['id'] ?>" title="<?= __('Edit') ?>">
-            <i data-lucide="pencil" class="h-4 w-4"></i>
-            <span class="sr-only"><?= __('Edit') ?></span>
-          </button>
+          <div class="flex items-center gap-2">
+            <button type="button" class="icon-action" data-open="#loan-history-<?= (int)$l['id'] ?>" title="<?= __('View history') ?>">
+              <i data-lucide="history" class="h-4 w-4"></i>
+              <span class="sr-only"><?= __('View history') ?></span>
+            </button>
+            <button type="button" class="icon-action icon-action--primary" data-open="#loan-edit-<?= (int)$l['id'] ?>" title="<?= __('Edit') ?>">
+              <i data-lucide="pencil" class="h-4 w-4"></i>
+              <span class="sr-only"><?= __('Edit') ?></span>
+            </button>
+          </div>
         </div>
 
         <div class="mt-2 text-xs text-gray-500">
@@ -653,53 +663,68 @@
         <button class="btn btn-primary" form="loan-pay-form-<?= (int)$l['id'] ?>"><?= __('Record Payment') ?></button>
       </div>
     </div>
+  </div>
+</div>
+<div id="loan-history-<?= (int)$l['id'] ?>" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="loan-history-title-<?= (int)$l['id'] ?>">
+  <div class="modal-backdrop" data-close></div>
 
-    <div class="px-6 pb-6">
-      <div class="mt-6">
-        <h4 class="font-semibold mb-3"><?= __('Payment history') ?></h4>
-        <?php if ($loanTxList): ?>
-          <div class="overflow-x-auto">
-            <table class="min-w-full text-sm">
-              <thead>
-                <tr class="text-left text-xs uppercase tracking-wide text-gray-500">
-                  <th class="py-2 pr-3"><?= __('Date') ?></th>
-                  <th class="py-2 pr-3"><?= __('Amount') ?></th>
-                  <th class="py-2 pr-3"><?= __('Breakdown') ?></th>
-                  <th class="py-2 pr-0 text-right"><?= __('Actions') ?></th>
-                </tr>
-              </thead>
-              <tbody>
-              <?php foreach ($loanTxList as $tx): $txId=(int)$tx['id']; $txCur = $tx['currency'] ?: $loanCurrency; ?>
-                <tr class="border-t">
-                  <td class="py-2 pr-3 align-middle text-sm"><?= htmlspecialchars($tx['paid_on']) ?></td>
-                  <td class="py-2 pr-3 align-middle text-sm">
-                    <?= moneyfmt((float)$tx['amount'], $txCur) ?>
-                    <?php if ($txCur && strtoupper($txCur) !== strtoupper($loanCurrency)): ?>
-                      <span class="text-xs text-gray-500">(<?= htmlspecialchars($txCur) ?>)</span>
-                    <?php endif; ?>
-                  </td>
-                  <td class="py-2 pr-3 align-middle text-xs text-gray-600">
-                    <?= __('Principal: :amount', ['amount' => moneyfmt((float)$tx['principal_component'], $txCur)]) ?> ·
-                    <?= __('Interest: :amount', ['amount' => moneyfmt((float)$tx['interest_component'], $txCur)]) ?>
-                  </td>
-                  <td class="py-2 pr-0 align-middle text-right">
-                    <div class="flex justify-end gap-2">
-                      <button type="button" class="btn !px-3" data-open="#loan-payment-edit-<?= $txId ?>"><?= __('Edit') ?></button>
-                      <form method="post" action="/loans/payment/delete" onsubmit="return confirm('<?= __('Delete this payment?') ?>');">
-                        <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
-                        <input type="hidden" name="id" value="<?= $txId ?>" />
-                        <button class="btn btn-danger !px-3" type="submit"><?= __('Delete') ?></button>
-                      </form>
-                    </div>
-                  </td>
-                </tr>
-              <?php endforeach; ?>
-              </tbody>
-            </table>
-          </div>
-        <?php else: ?>
-          <p class="text-sm text-gray-500"><?= __('No payments recorded yet.') ?></p>
-        <?php endif; ?>
+  <div class="modal-panel">
+    <div class="modal-header">
+      <h3 id="loan-history-title-<?= (int)$l['id'] ?>" class="font-semibold"><?= __('Payment history') ?></h3>
+      <button type="button" class="icon-btn" aria-label="<?= __('Close') ?>" data-close>
+        <i data-lucide="x" class="h-5 w-5"></i>
+      </button>
+    </div>
+
+    <div class="modal-body">
+      <?php if ($loanTxList): ?>
+        <div class="overflow-x-auto">
+          <table class="min-w-full text-sm">
+            <thead>
+              <tr class="text-left text-xs uppercase tracking-wide text-gray-500">
+                <th class="py-2 pr-3"><?= __('Date') ?></th>
+                <th class="py-2 pr-3"><?= __('Amount') ?></th>
+                <th class="py-2 pr-3"><?= __('Breakdown') ?></th>
+                <th class="py-2 pr-0 text-right"><?= __('Actions') ?></th>
+              </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($loanTxList as $tx): $txId=(int)$tx['id']; $txCur = $tx['currency'] ?: $loanCurrency; ?>
+              <tr class="border-t">
+                <td class="py-2 pr-3 align-middle text-sm"><?= htmlspecialchars($tx['paid_on']) ?></td>
+                <td class="py-2 pr-3 align-middle text-sm">
+                  <?= moneyfmt((float)$tx['amount'], $txCur) ?>
+                  <?php if ($txCur && strtoupper($txCur) !== strtoupper($loanCurrency)): ?>
+                    <span class="text-xs text-gray-500">(<?= htmlspecialchars($txCur) ?>)</span>
+                  <?php endif; ?>
+                </td>
+                <td class="py-2 pr-3 align-middle text-xs text-gray-600">
+                  <?= __('Principal: :amount', ['amount' => moneyfmt((float)$tx['principal_component'], $txCur)]) ?> ·
+                  <?= __('Interest: :amount', ['amount' => moneyfmt((float)$tx['interest_component'], $txCur)]) ?>
+                </td>
+                <td class="py-2 pr-0 align-middle text-right">
+                  <div class="flex justify-end gap-2">
+                    <button type="button" class="btn !px-3" data-open="#loan-payment-edit-<?= $txId ?>"><?= __('Edit') ?></button>
+                    <form method="post" action="/loans/payment/delete" onsubmit="return confirm('<?= __('Delete this payment?') ?>');">
+                      <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
+                      <input type="hidden" name="id" value="<?= $txId ?>" />
+                      <button class="btn btn-danger !px-3" type="submit"><?= __('Delete') ?></button>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+      <?php else: ?>
+        <p class="text-sm text-gray-500"><?= __('No payments recorded yet.') ?></p>
+      <?php endif; ?>
+    </div>
+
+    <div class="modal-footer">
+      <div class="flex justify-end">
+        <button type="button" class="btn" data-close><?= __('Close') ?></button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- fetch and expose goal contribution history alongside each goal and allow editing existing entries
- surface loan payment history within the loan modals, including edit/delete capabilities and balance adjustments
- wire up new routes and forms so both goal and loan transactions can be managed directly from the UI

## Testing
- php -l src/controllers/goals.php
- php -l src/controllers/loans.php
- php -l views/goals/index.php
- php -l views/loans/index.php
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68df4e234d58832999e99a0057691188