### PR TITLE
Fix mobile nav position when keyboard is open

### DIFF
--- a/views/layout/footer.php
+++ b/views/layout/footer.php
@@ -292,6 +292,32 @@
     };
   </script>
 
+  <script>
+    (function () {
+      const nav = document.querySelector('.mobile-nav');
+      if (!nav) {
+        return;
+      }
+
+      const viewport = window.visualViewport;
+      if (!viewport) {
+        return;
+      }
+
+      const updateOffset = () => {
+        const heightDiff = Math.max(0, Math.round(window.innerHeight - viewport.height - viewport.offsetTop));
+        nav.style.setProperty('--mobile-nav-offset', heightDiff > 0 ? `${heightDiff}px` : '0px');
+      };
+
+      viewport.addEventListener('resize', updateOffset);
+      viewport.addEventListener('scroll', updateOffset);
+      window.addEventListener('orientationchange', updateOffset);
+      window.addEventListener('resize', updateOffset);
+
+      updateOffset();
+    })();
+  </script>
+
   <script src="https://unpkg.com/lucide@latest"></script>
   <script>
     lucide.createIcons();

--- a/views/layout/header.php
+++ b/views/layout/header.php
@@ -735,12 +735,13 @@
         left: 0;
         right: 0;
         bottom: 0;
+        --mobile-nav-offset: 0px;
         padding-top: 0.4rem;
         padding-bottom: 0.6rem;
         padding-bottom: calc(env(safe-area-inset-bottom) + 0.6rem);
         box-shadow: 0 -20px 36px -24px rgba(17, 36, 29, 0.45);
         transition: transform 0.3s ease, opacity 0.3s ease;
-        transform: translateZ(0);
+        transform: translate3d(0, var(--mobile-nav-offset), 0);
         will-change: transform;
         contain: layout paint;
         backface-visibility: hidden;


### PR DESCRIPTION
## Summary
- ensure the mobile navigation keeps a stable transform baseline by introducing a CSS offset variable
- adjust the transform to use the offset and add a visual viewport listener to push the bar beneath the onscreen keyboard when it appears

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfa5eff944832995e8481205a7941a