### PR TITLE
Guard keyboard inset padding adjustments on iOS

### DIFF
--- a/views/layout/header.php
+++ b/views/layout/header.php
@@ -114,6 +114,16 @@
   </script>
   <script>
     (function() {
+      const nav = window.navigator || {};
+      const ua = nav.userAgent || '';
+      const platform = nav.platform || '';
+      const maxTouchPoints = typeof nav.maxTouchPoints === 'number' ? nav.maxTouchPoints : 0;
+      const isIOS = /iPad|iPhone|iPod/.test(ua) || (platform === 'MacIntel' && maxTouchPoints > 1);
+      document.documentElement.classList.toggle('is-ios', Boolean(isIOS));
+    })();
+  </script>
+  <script>
+    (function() {
       const storageKey = 'mymoneymap-theme';
       const root = document.documentElement;
       const getStored = () => {
@@ -190,6 +200,11 @@
       @media (max-width: 767px) {
         body.has-mobile-nav {
           padding-bottom: calc(env(safe-area-inset-bottom) + 5.5rem);
+        }
+        @supports (bottom: env(keyboard-inset-height)) {
+          html:not(.is-ios) body.has-mobile-nav {
+            padding-bottom: calc(env(safe-area-inset-bottom) + env(keyboard-inset-height) + 5.5rem);
+          }
         }
       }
       :root[data-theme='dark'] body {
@@ -744,6 +759,11 @@
         will-change: transform;
         contain: layout paint;
         backface-visibility: hidden;
+      }
+      @supports (bottom: env(keyboard-inset-height)) {
+        html:not(.is-ios) .mobile-nav {
+          padding-bottom: calc(env(safe-area-inset-bottom) + env(keyboard-inset-height) + 0.6rem);
+        }
       }
       .dark .mobile-nav {
         box-shadow: 0 -20px 40px -26px rgba(0, 0, 0, 0.65);


### PR DESCRIPTION
## Summary
- add an early script that toggles an `is-ios` class on the root element when running on iOS
- guard the mobile navigation keyboard inset padding adjustments so they only apply on non-iOS browsers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dfb0b3d48c8329aca2475bd2c89ced