### PR TITLE
Add email notifications and digests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,26 @@ MM_DB_PASS=postgres
 
 # 32-byte secret used to encrypt personal data (base64-encoded here).
 MM_DATA_KEY=REPLACE_WITH_44_CHAR_BASE64_SECRET
+
+# Base URL used to generate absolute links in emails.
+MM_APP_URL=http://localhost:8080
+
+# Mailer configuration
+# Set MM_MAIL_TRANSPORT to "log" (default) to write emails to storage/logs/mail.log,
+# "smtp" to send via an SMTP server, or "mail" to use PHP's mail()/sendmail transport.
+MM_MAIL_TRANSPORT=log
+MM_MAIL_FROM_ADDRESS=no-reply@example.com
+MM_MAIL_FROM_NAME="MyMoneyMap"
+# Optional reply-to address for outbound emails (leave empty to reuse the from address).
+# MM_MAIL_REPLY_TO=support@example.com
+
+# SMTP settings (used when MM_MAIL_TRANSPORT=smtp)
+MM_MAIL_SMTP_HOST=127.0.0.1
+MM_MAIL_SMTP_PORT=1025
+# Uncomment if your SMTP server requires authentication
+# MM_MAIL_SMTP_USER=
+# MM_MAIL_SMTP_PASS=
+# Use "tls" or "ssl" for encryption, leave empty for none.
+# MM_MAIL_SMTP_ENCRYPTION=
+# Connection timeout in seconds.
+# MM_MAIL_SMTP_TIMEOUT=15

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Modern, mobile‑first personal finance tracker using Tailwind CSS and Chart.js.
     ```bash
     php scripts/encrypt_full_names.php
     ```
--   **Database connection** – Credentials are read from the environment. For production deployments consider using managed secrets stores and enforcing TLS connections to PostgreSQL.
+-   **Database connection** – Credentials are read from the environment. For production deployments consider using managed secrets stores and enforcing TLS connections to PostgreSQL. When running the CLI helpers locally, make sure `MM_DB_USER`/`MM_DB_PASS` in `.env` match an existing PostgreSQL role so the scripts can connect.
 -   **Dave Ramsey support** – use `baby_steps` for status + `emergency_fund`, `goals`, `loans` to reflect progress.
 
 ## Email notifications

--- a/README.md
+++ b/README.md
@@ -60,5 +60,10 @@ Modern, mobile‑first personal finance tracker using Tailwind CSS and Chart.js.
     php scripts/send_user_emails.php weekly
     php scripts/send_user_emails.php monthly
     ```
+    To resend verification emails to every account without `email_verified_at`, run:
+    ```bash
+    php scripts/send_verification_emails.php
+    # Use --refresh-token to generate new tokens for each user if needed.
+    ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -50,4 +50,15 @@ Modern, mobile‑first personal finance tracker using Tailwind CSS and Chart.js.
 -   **Database connection** – Credentials are read from the environment. For production deployments consider using managed secrets stores and enforcing TLS connections to PostgreSQL.
 -   **Dave Ramsey support** – use `baby_steps` for status + `emergency_fund`, `goals`, `loans` to reflect progress.
 
+## Email notifications
+
+-   Configure sender details in `.env` using the `MM_MAIL_*` variables. By default, messages are written to `storage/logs/mail.log` so you can test locally without an SMTP server.
+-   Set `MM_MAIL_TRANSPORT=smtp` and provide the SMTP host, port, credentials, and encryption to deliver messages from production (e.g. Nethely).
+-   The application automatically sends verification and welcome emails after registration. Additional digests can be sent via CLI:
+    ```bash
+    php scripts/send_user_emails.php tips
+    php scripts/send_user_emails.php weekly
+    php scripts/send_user_emails.php monthly
+    ```
+
 ```

--- a/config/config.php
+++ b/config/config.php
@@ -13,12 +13,30 @@ return [
     'app' => [
         'name' => 'MyMoneyMap',
         'base_url' => '/', // if hosted in subfolder, e.g. '/moneymap/'
+        'url' => getenv('MM_APP_URL') ?: 'http://localhost:8080',
         'session_name' => 'moneymap_sess',
         'default_locale' => 'en',
         'locales' => [
             'en' => 'English',
             'hu' => 'Magyar',
             'es' => 'Español',
+        ],
+    ],
+    'mail' => [
+        'transport' => getenv('MM_MAIL_TRANSPORT') ?: 'log',
+        'from_email' => getenv('MM_MAIL_FROM_ADDRESS') ?: 'no-reply@mymoneymap.local',
+        'from_name' => getenv('MM_MAIL_FROM_NAME') ?: 'MyMoneyMap',
+        'reply_to' => getenv('MM_MAIL_REPLY_TO') ?: null,
+        'smtp' => [
+            'host' => getenv('MM_MAIL_SMTP_HOST') ?: '127.0.0.1',
+            'port' => (int)(getenv('MM_MAIL_SMTP_PORT') ?: 1025),
+            'username' => getenv('MM_MAIL_SMTP_USER') ?: null,
+            'password' => getenv('MM_MAIL_SMTP_PASS') ?: null,
+            'encryption' => getenv('MM_MAIL_SMTP_ENCRYPTION') ?: '', // '', 'tls', or 'ssl'
+            'timeout' => (int)(getenv('MM_MAIL_SMTP_TIMEOUT') ?: 15),
+        ],
+        'log' => [
+            'path' => getenv('MM_MAIL_LOG_PATH') ?: __DIR__ . '/../storage/logs/mail.log',
         ],
     ],
     'stocks' => [

--- a/config/db.php
+++ b/config/db.php
@@ -9,6 +9,13 @@ try {
         PDO::ATTR_EMULATE_PREPARES => false,
     ]);
 } catch (PDOException $e) {
+    $message = 'DB connection failed: ' . $e->getMessage();
+
+    if (PHP_SAPI === 'cli') {
+        fwrite(STDERR, $message . PHP_EOL);
+        exit(1);
+    }
+
     http_response_code(500);
-    die('DB connection failed: ' . htmlspecialchars($e->getMessage()));
+    die('DB connection failed: ' . htmlspecialchars($e->getMessage(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
 }

--- a/index.php
+++ b/index.php
@@ -102,6 +102,11 @@ switch ($path) {
         register_step1_form(); // GET
         break;
 
+    case '/verify-email':
+        require __DIR__ . '/src/controllers/email_verification.php';
+        email_verification_handle($pdo);
+        break;
+
     // Onboarding
     case '/onboard/next':
         require_login();

--- a/migrations/011_user_email_notifications.sql
+++ b/migrations/011_user_email_notifications.sql
@@ -1,0 +1,9 @@
+-- Email verification + notification metadata
+ALTER TABLE users
+    ADD COLUMN email_verified_at TIMESTAMPTZ,
+    ADD COLUMN email_verification_token TEXT,
+    ADD COLUMN email_verification_sent_at TIMESTAMPTZ;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email_verification_token
+    ON users(email_verification_token)
+    WHERE email_verification_token IS NOT NULL;

--- a/scripts/send_user_emails.php
+++ b/scripts/send_user_emails.php
@@ -1,0 +1,67 @@
+<?php
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "This script must be run from the command line.\n");
+    exit(1);
+}
+
+require __DIR__ . '/../config/db.php';
+require __DIR__ . '/../src/helpers.php';
+require __DIR__ . '/../src/services/email_notifications.php';
+
+$type = $argv[1] ?? '';
+$validTypes = ['tips', 'weekly', 'monthly'];
+if (!in_array($type, $validTypes, true)) {
+    fwrite(STDERR, "Usage: php scripts/send_user_emails.php [" . implode('|', $validTypes) . "]\n");
+    exit(1);
+}
+
+$requiresVerification = in_array($type, ['tips', 'weekly', 'monthly'], true);
+
+$stmt = $pdo->query("SELECT id, email, full_name, email_verified_at, email_verification_token FROM users WHERE email IS NOT NULL AND email <> '' ORDER BY id");
+$users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+if (!$users) {
+    fwrite(STDOUT, "No users found.\n");
+    exit(0);
+}
+
+$sent = 0;
+$skipped = 0;
+
+foreach ($users as $user) {
+    $email = trim((string)$user['email']);
+    if ($email === '') {
+        $skipped++;
+        continue;
+    }
+
+    if ($requiresVerification && empty($user['email_verified_at'])) {
+        $skipped++;
+        continue;
+    }
+
+    $user['full_name_plain'] = $user['full_name'] ? pii_decrypt($user['full_name']) : '';
+
+    switch ($type) {
+        case 'tips':
+            $ok = email_send_tips($user);
+            break;
+        case 'weekly':
+            $ok = email_send_weekly_results($pdo, $user);
+            break;
+        case 'monthly':
+            $ok = email_send_monthly_results($pdo, $user);
+            break;
+        default:
+            $ok = false;
+    }
+
+    if ($ok) {
+        $sent++;
+        fwrite(STDOUT, "[SENT] {$email}\n");
+    } else {
+        fwrite(STDERR, "[FAILED] {$email}\n");
+    }
+}
+
+fwrite(STDOUT, "Done. Sent: {$sent}, Skipped: {$skipped}\n");

--- a/scripts/send_verification_emails.php
+++ b/scripts/send_verification_emails.php
@@ -1,0 +1,67 @@
+<?php
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "This script must be run from the command line.\n");
+    exit(1);
+}
+
+require __DIR__ . '/../config/db.php';
+require __DIR__ . '/../src/helpers.php';
+require __DIR__ . '/../src/services/email_notifications.php';
+
+$options = array_slice($argv, 1);
+$refreshToken = false;
+
+foreach ($options as $option) {
+    if ($option === '--help' || $option === '-h') {
+        fwrite(STDOUT, "Usage: php scripts/send_verification_emails.php [--refresh-token]\n");
+        fwrite(STDOUT, "  --refresh-token  Generate a new verification token for each user.\n");
+        exit(0);
+    }
+
+    if ($option === '--refresh-token') {
+        $refreshToken = true;
+        continue;
+    }
+
+    fwrite(STDERR, "Unknown option: {$option}\n");
+    fwrite(STDERR, "Usage: php scripts/send_verification_emails.php [--refresh-token]\n");
+    exit(1);
+}
+
+$stmt = $pdo->query("SELECT id, email, full_name, email_verified_at, email_verification_token FROM users " .
+    "WHERE email_verified_at IS NULL AND email IS NOT NULL AND email <> '' ORDER BY id");
+$users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+if (!$users) {
+    fwrite(STDOUT, "No unverified users found.\n");
+    exit(0);
+}
+
+$sent = 0;
+$failed = 0;
+
+foreach ($users as $user) {
+    $email = trim((string)$user['email']);
+    if ($email === '') {
+        continue;
+    }
+
+    $user['full_name_plain'] = $user['full_name'] ? pii_decrypt($user['full_name']) : '';
+
+    try {
+        $ok = email_send_verification($pdo, $user, $refreshToken);
+    } catch (Throwable $e) {
+        $ok = false;
+        error_log('[mail] Failed to send verification email to ' . $email . ': ' . $e->getMessage());
+    }
+
+    if ($ok) {
+        $sent++;
+        fwrite(STDOUT, "[SENT] {$email}\n");
+    } else {
+        $failed++;
+        fwrite(STDERR, "[FAILED] {$email}\n");
+    }
+}
+
+fwrite(STDOUT, "Done. Sent: {$sent}, Failed: {$failed}\n");

--- a/src/controllers/auth.php
+++ b/src/controllers/auth.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../helpers.php';
+require_once __DIR__ . '/../services/email_notifications.php';
 
 function register_step1_form() {
   view('auth/register_step1', []); // use your new pretty form UI
@@ -39,6 +40,13 @@ function register_step1_submit(PDO $pdo) {
 
   // Log in + jump to step 1
   $uid = (int)$pdo->lastInsertId();
+
+  email_send_registration_bundle($pdo, [
+    'id' => $uid,
+    'email' => $email,
+    'full_name_plain' => $name,
+  ]);
+
   $_SESSION['uid'] = $uid;
   redirect('/onboard/theme');
 }

--- a/src/controllers/email_verification.php
+++ b/src/controllers/email_verification.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . '/../helpers.php';
+
+function email_verification_handle(PDO $pdo): void
+{
+    $token = trim((string)($_GET['token'] ?? ''));
+    if ($token === '') {
+        view('auth/verify_email', [
+            'status' => 'missing',
+        ]);
+        return;
+    }
+
+    $stmt = $pdo->prepare('SELECT id, email_verified_at FROM users WHERE email_verification_token = ? LIMIT 1');
+    $stmt->execute([$token]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$user) {
+        view('auth/verify_email', [
+            'status' => 'invalid',
+        ]);
+        return;
+    }
+
+    if (!empty($user['email_verified_at'])) {
+        view('auth/verify_email', [
+            'status' => 'already',
+        ]);
+        return;
+    }
+
+    $pdo->prepare('UPDATE users SET email_verified_at = NOW(), email_verification_token = NULL WHERE id = ?')
+        ->execute([(int)$user['id']]);
+
+    view('auth/verify_email', [
+        'status' => 'success',
+    ]);
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -259,6 +259,31 @@ function app_config(?string $section = null)
     return $config[$section] ?? null;
 }
 
+function app_url(string $path = ''): string
+{
+    $app = app_config('app') ?? [];
+    $root = rtrim((string)($app['url'] ?? ''), '/');
+    $base = rtrim((string)($app['base_url'] ?? ''), '/');
+
+    $url = $root;
+    if ($base !== '' && $base !== '/') {
+        $url .= $base;
+    }
+
+    $path = (string)$path;
+    if ($path !== '') {
+        if ($path[0] !== '/' && $path[0] !== '?') {
+            $path = '/' . $path;
+        }
+    }
+
+    if ($url === '') {
+        return $path !== '' ? $path : '/';
+    }
+
+    return $url . $path;
+}
+
 function available_locales(): array
 {
     $app = app_config('app') ?? [];

--- a/src/mailer.php
+++ b/src/mailer.php
@@ -1,0 +1,231 @@
+<?php
+require_once __DIR__ . '/helpers.php';
+
+function mailer_config(): array
+{
+    $config = app_config('mail');
+    return is_array($config) ? $config : [];
+}
+
+function mailer_format_address(string $email, ?string $name = null): string
+{
+    $email = trim($email);
+    if ($name === null || $name === '') {
+        return $email;
+    }
+
+    return mailer_encode_header($name) . ' <' . $email . '>';
+}
+
+function mailer_encode_header(string $value): string
+{
+    if ($value === '') {
+        return '';
+    }
+
+    if (function_exists('mb_encode_mimeheader')) {
+        return mb_encode_mimeheader($value, 'UTF-8', 'B', "\r\n", 'UTF-8');
+    }
+
+    return '=?UTF-8?B?' . base64_encode($value) . '?=';
+}
+
+function send_app_email(string $toEmail, string $subject, string $htmlBody, ?string $textBody = null, array $options = []): bool
+{
+    $config = mailer_config();
+    $transport = strtolower((string)($config['transport'] ?? 'log'));
+
+    $fromEmail = $options['from_email'] ?? ($config['from_email'] ?? 'no-reply@example.com');
+    $fromName  = $options['from_name']  ?? ($config['from_name']  ?? 'MyMoneyMap');
+
+    $replyToEmail = $options['reply_to'] ?? ($config['reply_to'] ?? $fromEmail);
+    $replyToName  = $options['reply_to_name'] ?? ($options['from_name'] ?? ($config['from_name'] ?? 'MyMoneyMap'));
+
+    $toName = $options['to_name'] ?? null;
+
+    $fromHeader = mailer_format_address($fromEmail, $fromName);
+    $toHeader   = mailer_format_address($toEmail, $toName);
+    $replyToHeader = $replyToEmail ? mailer_format_address($replyToEmail, $replyToName) : null;
+
+    if ($textBody === null) {
+        $textBody = trim(html_entity_decode(strip_tags($htmlBody), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+    }
+
+    $boundary = '=_Part_' . bin2hex(random_bytes(16));
+    $dateHeader = 'Date: ' . date('r');
+
+    $mimeHeaders = [
+        'MIME-Version: 1.0',
+        'Content-Type: multipart/alternative; boundary="' . $boundary . '"',
+        'X-Mailer: MyMoneyMap Mailer',
+    ];
+
+    $commonHeaders = array_merge([$dateHeader, 'From: ' . $fromHeader], $mimeHeaders);
+    if ($replyToHeader) {
+        $commonHeaders[] = 'Reply-To: ' . $replyToHeader;
+    }
+
+    $encodedSubject = mailer_encode_header($subject);
+
+    $bodyParts = [];
+    $bodyParts[] = "--{$boundary}\r\n" .
+        "Content-Type: text/plain; charset=UTF-8\r\n" .
+        "Content-Transfer-Encoding: 8bit\r\n\r\n" .
+        $textBody . "\r\n";
+    $bodyParts[] = "--{$boundary}\r\n" .
+        "Content-Type: text/html; charset=UTF-8\r\n" .
+        "Content-Transfer-Encoding: 8bit\r\n\r\n" .
+        $htmlBody . "\r\n";
+    $bodyParts[] = "--{$boundary}--\r\n";
+    $body = implode('', $bodyParts);
+
+    $dataHeaders = array_merge([
+        $dateHeader,
+        'From: ' . $fromHeader,
+        'To: ' . $toHeader,
+        'Subject: ' . $encodedSubject,
+    ], $replyToHeader ? ['Reply-To: ' . $replyToHeader] : []);
+    $dataHeaders = array_merge($dataHeaders, $mimeHeaders);
+
+    switch ($transport) {
+        case 'smtp':
+            return mailer_send_via_smtp($config, [
+                'from_email' => $fromEmail,
+                'to_email' => $toEmail,
+                'data_headers' => $dataHeaders,
+                'body' => $body,
+            ]);
+        case 'mail':
+            return mailer_send_via_mail($toHeader, $encodedSubject, $commonHeaders, $body);
+        case 'log':
+        default:
+            return mailer_log_message($config, $toHeader, $subject, $dataHeaders, $body);
+    }
+}
+
+function mailer_send_via_mail(string $toHeader, string $encodedSubject, array $headers, string $body): bool
+{
+    $headersString = implode("\r\n", $headers);
+    return mail($toHeader, $encodedSubject, $body, $headersString);
+}
+
+function mailer_log_message(array $config, string $toHeader, string $subject, array $dataHeaders, string $body): bool
+{
+    $path = $config['log']['path'] ?? (__DIR__ . '/../storage/logs/mail.log');
+    $dir = dirname($path);
+    if (!is_dir($dir)) {
+        @mkdir($dir, 0775, true);
+    }
+
+    $entry = str_repeat('=', 60) . "\n" .
+        date('c') . "\n" .
+        "To: {$toHeader}\n" .
+        "Subject: {$subject}\n" .
+        implode("\n", $dataHeaders) . "\n\n" .
+        $body . "\n";
+
+    return file_put_contents($path, $entry, FILE_APPEND) !== false;
+}
+
+function mailer_send_via_smtp(array $config, array $message): bool
+{
+    $smtp = $config['smtp'] ?? [];
+    $host = $smtp['host'] ?? '127.0.0.1';
+    $port = (int)($smtp['port'] ?? 25);
+    $timeout = max(5, (int)($smtp['timeout'] ?? 15));
+    $encryption = strtolower((string)($smtp['encryption'] ?? ''));
+
+    $remote = ($encryption === 'ssl' ? 'ssl://' : 'tcp://') . $host . ':' . $port;
+    $errno = 0;
+    $errstr = '';
+    $stream = @stream_socket_client($remote, $errno, $errstr, $timeout, STREAM_CLIENT_CONNECT);
+    if (!$stream) {
+        error_log('[mail] SMTP connection failed: ' . $errstr);
+        return false;
+    }
+
+    stream_set_timeout($stream, $timeout);
+
+    try {
+        mailer_smtp_expect($stream, [220]);
+        $hostname = gethostname() ?: 'localhost';
+        mailer_smtp_write($stream, 'EHLO ' . $hostname);
+        mailer_smtp_expect($stream, [250]);
+
+        if ($encryption === 'tls') {
+            mailer_smtp_write($stream, 'STARTTLS');
+            mailer_smtp_expect($stream, [220]);
+            $cryptoMethod = defined('STREAM_CRYPTO_METHOD_TLS_CLIENT')
+                ? STREAM_CRYPTO_METHOD_TLS_CLIENT
+                : (STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT | (defined('STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT') ? STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT : 0));
+            if (!@stream_socket_enable_crypto($stream, true, $cryptoMethod)) {
+                throw new RuntimeException('Failed to negotiate TLS with SMTP server.');
+            }
+            mailer_smtp_write($stream, 'EHLO ' . $hostname);
+            mailer_smtp_expect($stream, [250]);
+        }
+
+        $username = $smtp['username'] ?? null;
+        $password = $smtp['password'] ?? null;
+        if ($username) {
+            mailer_smtp_write($stream, 'AUTH LOGIN');
+            mailer_smtp_expect($stream, [334]);
+            mailer_smtp_write($stream, base64_encode((string)$username));
+            mailer_smtp_expect($stream, [334]);
+            mailer_smtp_write($stream, base64_encode((string)$password));
+            mailer_smtp_expect($stream, [235]);
+        }
+
+        $from = $message['from_email'] ?? '';
+        $to = $message['to_email'] ?? '';
+        if (!$from || !$to) {
+            throw new RuntimeException('Missing from/to email for SMTP send.');
+        }
+
+        mailer_smtp_write($stream, 'MAIL FROM:<' . $from . '>');
+        mailer_smtp_expect($stream, [250, 251]);
+        mailer_smtp_write($stream, 'RCPT TO:<' . $to . '>');
+        mailer_smtp_expect($stream, [250, 251]);
+        mailer_smtp_write($stream, 'DATA');
+        mailer_smtp_expect($stream, [354]);
+
+        $data = implode("\r\n", $message['data_headers'] ?? []) . "\r\n\r\n" . ($message['body'] ?? '') . "\r\n.\r\n";
+        mailer_smtp_write($stream, $data, false);
+        mailer_smtp_expect($stream, [250]);
+        mailer_smtp_write($stream, 'QUIT');
+        mailer_smtp_expect($stream, [221]);
+    } catch (Throwable $e) {
+        error_log('[mail] SMTP send failed: ' . $e->getMessage());
+        fclose($stream);
+        return false;
+    }
+
+    fclose($stream);
+    return true;
+}
+
+function mailer_smtp_write($stream, string $command, bool $appendNewline = true): void
+{
+    $payload = $command;
+    if ($appendNewline) {
+        $payload .= "\r\n";
+    }
+    fwrite($stream, $payload);
+}
+
+function mailer_smtp_expect($stream, array $expectedCodes): void
+{
+    $response = '';
+    while (($line = fgets($stream, 515)) !== false) {
+        $response .= $line;
+        if (isset($line[3]) && $line[3] === ' ') {
+            $code = (int)substr($line, 0, 3);
+            if (!in_array($code, $expectedCodes, true)) {
+                throw new RuntimeException('Unexpected SMTP response: ' . trim($response));
+            }
+            return;
+        }
+    }
+
+    throw new RuntimeException('SMTP connection closed unexpectedly.');
+}

--- a/src/mailer.php
+++ b/src/mailer.php
@@ -24,7 +24,7 @@ function mailer_encode_header(string $value): string
     }
 
     if (function_exists('mb_encode_mimeheader')) {
-        return mb_encode_mimeheader($value, 'UTF-8', 'B', "\r\n", 'UTF-8');
+        return mb_encode_mimeheader($value, 'UTF-8', 'B', "\r\n", 0);
     }
 
     return '=?UTF-8?B?' . base64_encode($value) . '?=';

--- a/src/services/email_notifications.php
+++ b/src/services/email_notifications.php
@@ -1,0 +1,268 @@
+<?php
+require_once __DIR__ . '/../helpers.php';
+require_once __DIR__ . '/../mailer.php';
+require_once __DIR__ . '/../fx.php';
+
+function email_user_display_name(array $user): string
+{
+    $name = trim((string)($user['full_name_plain'] ?? ''));
+    if ($name === '' && !empty($user['full_name'])) {
+        $name = trim((string)pii_decrypt($user['full_name']));
+    }
+    if ($name === '') {
+        $name = trim((string)($user['email'] ?? ''));
+    }
+
+    return $name;
+}
+
+function email_generate_verification_token(PDO $pdo, int $userId): string
+{
+    $token = bin2hex(random_bytes(32));
+    $stmt = $pdo->prepare('UPDATE users SET email_verification_token = ?, email_verification_sent_at = NOW() WHERE id = ?');
+    $stmt->execute([$token, $userId]);
+    return $token;
+}
+
+function email_send_verification(PDO $pdo, array $user, bool $refreshToken = true): bool
+{
+    if (!empty($user['email_verified_at'])) {
+        return true;
+    }
+
+    $token = null;
+    if (!$refreshToken && !empty($user['email_verification_token'])) {
+        $token = (string)$user['email_verification_token'];
+    }
+
+    if ($token === null || $token === '') {
+        $token = email_generate_verification_token($pdo, (int)$user['id']);
+    }
+
+    $link = app_url('/verify-email?token=' . urlencode($token));
+    $name = email_user_display_name($user);
+
+    $html = '<p>Hi ' . htmlspecialchars($name) . ',</p>' .
+        '<p>Thanks for creating a MyMoneyMap account. Please confirm your email address so we can keep your data safe and share updates with you.</p>' .
+        '<p><a href="' . htmlspecialchars($link) . '" style="display:inline-block;padding:10px 18px;background:#2563eb;color:#fff;text-decoration:none;border-radius:6px;">Verify my email</a></p>' .
+        '<p>If the button does not work, copy and paste this link into your browser:<br /><span style="word-break:break-all;">' . htmlspecialchars($link) . '</span></p>' .
+        '<p>See you soon,<br />The MyMoneyMap team</p>';
+
+    $text = "Hi {$name},\n\n" .
+        "Thanks for creating a MyMoneyMap account. Please confirm your email address so we can keep your data safe and share updates with you.\n\n" .
+        "Verify your email: {$link}\n\n" .
+        "See you soon,\nThe MyMoneyMap team";
+
+    return send_app_email((string)$user['email'], 'Verify your email address', $html, $text, [
+        'to_name' => $name,
+    ]);
+}
+
+function email_send_welcome(array $user): bool
+{
+    $name = email_user_display_name($user);
+    $html = '<p>Hi ' . htmlspecialchars($name) . ',</p>' .
+        '<p>Your MyMoneyMap registration was successful. You can start tracking your finances right away — add accounts, record transactions, and set your goals.</p>' .
+        '<ul>' .
+        '<li>Record today\'s income and spending from the dashboard.</li>' .
+        '<li>Invite MyMoneyMap into your routine with weekly reviews.</li>' .
+        '<li>Explore Baby Steps, emergency funds, and long-term goals.</li>' .
+        '</ul>' .
+        '<p>We\'re thrilled to have you on board!<br />— The MyMoneyMap team</p>';
+
+    $text = "Hi {$name},\n\n" .
+        "Your MyMoneyMap registration was successful. Start tracking your finances right away: add transactions, review budgets, and set meaningful goals.\n\n" .
+        "We\'re thrilled to have you on board!\n— The MyMoneyMap team";
+
+    return send_app_email((string)$user['email'], 'Welcome to MyMoneyMap', $html, $text, [
+        'to_name' => $name,
+    ]);
+}
+
+function email_send_registration_bundle(PDO $pdo, array $user): void
+{
+    try {
+        email_send_verification($pdo, $user, true);
+    } catch (Throwable $e) {
+        error_log('[mail] Failed to send verification email: ' . $e->getMessage());
+    }
+
+    try {
+        email_send_welcome($user);
+    } catch (Throwable $e) {
+        error_log('[mail] Failed to send welcome email: ' . $e->getMessage());
+    }
+}
+
+function email_default_tips(): array
+{
+    return [
+        'Categorise every transaction to understand where your money goes.',
+        'Set a weekly review reminder to reconcile your spending and progress.',
+        'Use scheduled payments to automate recurring bills and savings transfers.',
+    ];
+}
+
+function email_send_tips(array $user, ?array $tips = null): bool
+{
+    $tips = $tips && is_array($tips) ? $tips : email_default_tips();
+    $name = email_user_display_name($user);
+
+    $html = '<p>Hi ' . htmlspecialchars($name) . ',</p>' .
+        '<p>Here are a few tips to help you get even more value from MyMoneyMap:</p>' .
+        '<ul>';
+    foreach ($tips as $tip) {
+        $html .= '<li>' . htmlspecialchars($tip) . '</li>';
+    }
+    $html .= '</ul><p>Happy tracking!<br />— The MyMoneyMap team</p>';
+
+    $text = "Hi {$name},\n\n" .
+        "Here are a few tips to help you get more value from MyMoneyMap:\n" .
+        implode("\n", array_map(fn($tip) => '• ' . $tip, $tips)) . "\n\n" .
+        "Happy tracking!\n— The MyMoneyMap team";
+
+    return send_app_email((string)$user['email'], 'Tips & tricks for MyMoneyMap', $html, $text, [
+        'to_name' => $name,
+    ]);
+}
+
+function email_collect_period_summary(PDO $pdo, int $userId, DateTimeImmutable $start, DateTimeImmutable $end): array
+{
+    $stmt = $pdo->prepare('SELECT t.kind, t.amount, t.currency, t.occurred_on, c.label AS category_label ' .
+        'FROM transactions t LEFT JOIN categories c ON c.id = t.category_id ' .
+        'WHERE t.user_id = ? AND t.occurred_on BETWEEN ?::date AND ?::date ORDER BY t.occurred_on');
+    $stmt->execute([$userId, $start->format('Y-m-d'), $end->format('Y-m-d')]);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $mainCurrency = fx_user_main($pdo, $userId);
+    $incomeTotal = 0.0;
+    $spendingTotal = 0.0;
+    $incomeCount = 0;
+    $spendingCount = 0;
+    $categories = [];
+
+    foreach ($rows as $row) {
+        $amount = (float)$row['amount'];
+        $currency = $row['currency'] ?: $mainCurrency;
+        $date = $row['occurred_on'] ?: $end->format('Y-m-d');
+        $converted = $currency === $mainCurrency ? $amount : fx_convert($pdo, $amount, $currency, $mainCurrency, $date);
+
+        if ($row['kind'] === 'income') {
+            $incomeTotal += $converted;
+            $incomeCount++;
+        } else {
+            $spendingTotal += $converted;
+            $spendingCount++;
+            $label = $row['category_label'] ?? 'Other';
+            if ($label === null || $label === '') {
+                $label = 'Other';
+            }
+            $categories[$label] = ($categories[$label] ?? 0.0) + $converted;
+        }
+    }
+
+    arsort($categories, SORT_NUMERIC);
+    $topCategories = array_slice($categories, 0, 3, true);
+
+    return [
+        'currency' => $mainCurrency,
+        'income_total' => $incomeTotal,
+        'spending_total' => $spendingTotal,
+        'income_count' => $incomeCount,
+        'spending_count' => $spendingCount,
+        'net' => $incomeTotal - $spendingTotal,
+        'top_categories' => $topCategories,
+        'transaction_count' => count($rows),
+    ];
+}
+
+function email_format_amount(float $amount, string $currency): string
+{
+    return moneyfmt($amount, $currency);
+}
+
+function email_period_label(DateTimeImmutable $start, DateTimeImmutable $end): string
+{
+    return $start->format('M j, Y') . ' – ' . $end->format('M j, Y');
+}
+
+function email_send_period_results(PDO $pdo, array $user, DateTimeImmutable $start, DateTimeImmutable $end, string $label): bool
+{
+    $summary = email_collect_period_summary($pdo, (int)$user['id'], $start, $end);
+    $name = email_user_display_name($user);
+    $rangeLabel = email_period_label($start, $end);
+    $currency = $summary['currency'];
+
+    $html = '<p>Hi ' . htmlspecialchars($name) . ',</p>' .
+        '<p>Here is your ' . htmlspecialchars($label) . ' summary for ' . htmlspecialchars($rangeLabel) . '.</p>';
+
+    if ($summary['transaction_count'] === 0) {
+        $html .= '<p>No transactions were recorded during this period. Add new entries from your dashboard to keep your finances up to date.</p>';
+    } else {
+        $html .= '<table style="border-collapse:collapse;width:100%;max-width:480px;margin:16px 0;">'
+            . '<tr><td style="padding:8px;border:1px solid #e2e8f0;">Income</td><td style="padding:8px;border:1px solid #e2e8f0;text-align:right;">'
+            . htmlspecialchars(email_format_amount($summary['income_total'], $currency)) . '</td></tr>'
+            . '<tr><td style="padding:8px;border:1px solid #e2e8f0;">Spending</td><td style="padding:8px;border:1px solid #e2e8f0;text-align:right;">'
+            . htmlspecialchars(email_format_amount($summary['spending_total'], $currency)) . '</td></tr>'
+            . '<tr><td style="padding:8px;border:1px solid #e2e8f0;">Net</td><td style="padding:8px;border:1px solid #e2e8f0;text-align:right;">'
+            . htmlspecialchars(email_format_amount($summary['net'], $currency)) . '</td></tr>'
+            . '</table>';
+
+        if ($summary['top_categories']) {
+            $html .= '<p>Top spending categories:</p><ul>';
+            foreach ($summary['top_categories'] as $category => $amount) {
+                $html .= '<li>' . htmlspecialchars($category) . ' — ' . htmlspecialchars(email_format_amount($amount, $currency)) . '</li>';
+            }
+            $html .= '</ul>';
+        }
+    }
+
+    $html .= '<p>Keep going — every entry moves you closer to your goals.<br />— The MyMoneyMap team</p>';
+
+    $textLines = [
+        "Hi {$name},",
+        '',
+        "Here is your {$label} summary for {$rangeLabel}.",
+    ];
+    if ($summary['transaction_count'] === 0) {
+        $textLines[] = 'No transactions were recorded during this period. Add new entries from your dashboard to stay on track.';
+    } else {
+        $textLines[] = 'Income: ' . email_format_amount($summary['income_total'], $currency);
+        $textLines[] = 'Spending: ' . email_format_amount($summary['spending_total'], $currency);
+        $textLines[] = 'Net: ' . email_format_amount($summary['net'], $currency);
+        if ($summary['top_categories']) {
+            $textLines[] = '';
+            $textLines[] = 'Top spending categories:';
+            foreach ($summary['top_categories'] as $category => $amount) {
+                $textLines[] = ' • ' . $category . ' — ' . email_format_amount($amount, $currency);
+            }
+        }
+    }
+    $textLines[] = '';
+    $textLines[] = 'Keep going — every entry moves you closer to your goals.';
+    $textLines[] = '— The MyMoneyMap team';
+
+    $subject = 'Your ' . ucfirst($label) . ' MyMoneyMap summary';
+
+    return send_app_email((string)$user['email'], $subject, $html, implode("\n", $textLines), [
+        'to_name' => $name,
+    ]);
+}
+
+function email_send_weekly_results(PDO $pdo, array $user, ?DateTimeImmutable $reference = null): bool
+{
+    $reference = $reference ?? new DateTimeImmutable('today');
+    $end = $reference;
+    $start = $end->modify('-6 days');
+
+    return email_send_period_results($pdo, $user, $start, $end, 'weekly');
+}
+
+function email_send_monthly_results(PDO $pdo, array $user, ?DateTimeImmutable $reference = null): bool
+{
+    $reference = $reference ?? new DateTimeImmutable('first day of this month');
+    $start = $reference->modify('-1 month');
+    $end = $reference->modify('-1 day');
+
+    return email_send_period_results($pdo, $user, $start, $end, 'monthly');
+}

--- a/storage/logs/.gitignore
+++ b/storage/logs/.gitignore
@@ -1,3 +1,2 @@
 *
 !.gitignore
-!logs/

--- a/views/auth/verify_email.php
+++ b/views/auth/verify_email.php
@@ -1,0 +1,18 @@
+<section class="mx-auto max-w-xl rounded-lg bg-white p-8 shadow dark:bg-slate-800">
+  <?php if (($status ?? '') === 'success'): ?>
+    <h1 class="text-2xl font-semibold text-emerald-600 dark:text-emerald-300">Email verified</h1>
+    <p class="mt-4 text-slate-600 dark:text-slate-200">Thank you! Your email address has been confirmed. You can close this window or continue using MyMoneyMap.</p>
+  <?php elseif (($status ?? '') === 'already'): ?>
+    <h1 class="text-2xl font-semibold text-indigo-600 dark:text-indigo-300">Already verified</h1>
+    <p class="mt-4 text-slate-600 dark:text-slate-200">This email address was already verified. You can continue using MyMoneyMap.</p>
+  <?php elseif (($status ?? '') === 'missing'): ?>
+    <h1 class="text-2xl font-semibold text-amber-600 dark:text-amber-300">Verification link missing</h1>
+    <p class="mt-4 text-slate-600 dark:text-slate-200">We couldn&rsquo;t find a verification token in your request. Please use the link from your email.</p>
+  <?php else: ?>
+    <h1 class="text-2xl font-semibold text-rose-600 dark:text-rose-300">Verification failed</h1>
+    <p class="mt-4 text-slate-600 dark:text-slate-200">The verification link is invalid or has expired. Please request a new verification email.</p>
+  <?php endif; ?>
+  <div class="mt-6">
+    <a class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-white shadow hover:bg-indigo-500" href="/">Return to MyMoneyMap</a>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add a configurable mailer with SMTP/log transports and environment variables
- send verification and welcome emails on registration and provide a verification endpoint and view
- add a CLI utility for tips, weekly, and monthly digests and document the email workflow

## Testing
- php -l src/mailer.php
- php -l src/services/email_notifications.php
- php -l src/controllers/email_verification.php
- php -l scripts/send_user_emails.php


------
https://chatgpt.com/codex/tasks/task_e_68e2530761248329b90a7760dd6698f9