### PR TITLE
Revamp email templates with branded design

### DIFF
--- a/src/services/email_notifications.php
+++ b/src/services/email_notifications.php
@@ -3,6 +3,66 @@ require_once __DIR__ . '/../helpers.php';
 require_once __DIR__ . '/../mailer.php';
 require_once __DIR__ . '/../fx.php';
 
+function email_brand_logo_url(): string
+{
+    return app_url('/logo.png');
+}
+
+function email_wrap_html(string $title, string $content): string
+{
+    $logoUrl = htmlspecialchars(email_brand_logo_url(), ENT_QUOTES, 'UTF-8');
+    $titleSafe = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
+
+    return '<!DOCTYPE html>' .
+        '<html lang="en">' .
+        '<head>' .
+        '<meta charset="utf-8" />' .
+        '<meta name="viewport" content="width=device-width,initial-scale=1" />' .
+        '<title>' . $titleSafe . '</title>' .
+        '<style>' .
+        'body{margin:0;background:#f8fafc;color:#0f172a;font-family:\'Inter\',\'Segoe UI\',Helvetica,Arial,sans-serif;}' .
+        'a{color:#2563eb;}' .
+        '@media (prefers-color-scheme:dark){body{background:#0f172a;color:#e2e8f0;}' .
+        '.email-card{background:#0b1120 !important;border-color:#1e293b !important;}' .
+        '.email-title{color:#38bdf8 !important;}' .
+        '.email-paragraph{color:#e2e8f0 !important;}' .
+        '.email-muted{color:#94a3b8 !important;}' .
+        '.email-button{background:#38bdf8 !important;color:#0b1120 !important;}' .
+        '}' .
+        '</style>' .
+        '</head>' .
+        '<body>' .
+        '<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="padding:32px 0;">' .
+        '<tr><td align="center">' .
+        '<table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;max-width:600px;padding:0 20px;">' .
+        '<tr><td style="text-align:center;padding-bottom:20px;">' .
+        '<img src="' . $logoUrl . '" alt="MyMoneyMap" style="height:48px;width:auto;" />' .
+        '</td></tr>' .
+        '<tr><td>' .
+        '<div class="email-card" style="background:#ffffff;border:1px solid #e2e8f0;border-radius:24px;padding:32px;box-shadow:0 20px 40px rgba(15,23,42,0.08);">' .
+        '<h1 class="email-title" style="margin:0 0 16px;font-size:24px;font-weight:600;color:#0f172a;">' . $titleSafe . '</h1>' .
+        '<div class="email-paragraph" style="font-size:15px;line-height:1.6;color:#1e293b;">' .
+        $content .
+        '</div>' .
+        '</div>' .
+        '</td></tr>' .
+        '<tr><td style="text-align:center;padding:28px 12px 0;">' .
+        '<p class="email-muted" style="margin:0;font-size:13px;line-height:1.5;color:#64748b;">You are receiving this email because you have a MyMoneyMap account.</p>' .
+        '</td></tr>' .
+        '</table>' .
+        '</td></tr>' .
+        '</table>' .
+        '</body>' .
+        '</html>';
+}
+
+function email_render_button(string $href, string $label): string
+{
+    return '<a href="' . htmlspecialchars($href, ENT_QUOTES, 'UTF-8') . '" ' .
+        'class="email-button" style="display:inline-block;padding:12px 24px;margin:12px 0;border-radius:999px;background:#2563eb;color:#ffffff;text-decoration:none;font-weight:600;">' .
+        htmlspecialchars($label, ENT_QUOTES, 'UTF-8') . '</a>';
+}
+
 function email_user_display_name(array $user): string
 {
     $name = trim((string)($user['full_name_plain'] ?? ''));
@@ -42,11 +102,13 @@ function email_send_verification(PDO $pdo, array $user, bool $refreshToken = tru
     $link = app_url('/verify-email?token=' . urlencode($token));
     $name = email_user_display_name($user);
 
-    $html = '<p>Hi ' . htmlspecialchars($name) . ',</p>' .
-        '<p>Thanks for creating a MyMoneyMap account. Please confirm your email address so we can keep your data safe and share updates with you.</p>' .
-        '<p><a href="' . htmlspecialchars($link) . '" style="display:inline-block;padding:10px 18px;background:#2563eb;color:#fff;text-decoration:none;border-radius:6px;">Verify my email</a></p>' .
-        '<p>If the button does not work, copy and paste this link into your browser:<br /><span style="word-break:break-all;">' . htmlspecialchars($link) . '</span></p>' .
-        '<p>See you soon,<br />The MyMoneyMap team</p>';
+    $body = '<p style="margin:0 0 16px;">Hi ' . htmlspecialchars($name) . ',</p>' .
+        '<p style="margin:0 0 16px;">Thanks for creating a MyMoneyMap account. Please confirm your email address so we can keep your data safe and share updates with you.</p>' .
+        '<p style="margin:0 0 16px;text-align:center;">' . email_render_button($link, 'Verify my email') . '</p>' .
+        '<p style="margin:0 0 16px;">If the button does not work, copy and paste this link into your browser:<br /><a href="' . htmlspecialchars($link) . '" style="word-break:break-all;color:#2563eb;">' . htmlspecialchars($link) . '</a></p>' .
+        '<p style="margin:0;">See you soon,<br />The MyMoneyMap team</p>';
+
+    $html = email_wrap_html('Verify your email', $body);
 
     $text = "Hi {$name},\n\n" .
         "Thanks for creating a MyMoneyMap account. Please confirm your email address so we can keep your data safe and share updates with you.\n\n" .
@@ -61,14 +123,16 @@ function email_send_verification(PDO $pdo, array $user, bool $refreshToken = tru
 function email_send_welcome(array $user): bool
 {
     $name = email_user_display_name($user);
-    $html = '<p>Hi ' . htmlspecialchars($name) . ',</p>' .
-        '<p>Your MyMoneyMap registration was successful. You can start tracking your finances right away — add accounts, record transactions, and set your goals.</p>' .
-        '<ul>' .
-        '<li>Record today\'s income and spending from the dashboard.</li>' .
-        '<li>Invite MyMoneyMap into your routine with weekly reviews.</li>' .
-        '<li>Explore Baby Steps, emergency funds, and long-term goals.</li>' .
+    $body = '<p style="margin:0 0 16px;">Hi ' . htmlspecialchars($name) . ',</p>' .
+        '<p style="margin:0 0 16px;">Your MyMoneyMap registration was successful. You can start tracking your finances right away — add accounts, record transactions, and set your goals.</p>' .
+        '<ul style="margin:0 0 16px;padding-left:20px;">' .
+        '<li style="margin-bottom:8px;">Record today\'s income and spending from the dashboard.</li>' .
+        '<li style="margin-bottom:8px;">Invite MyMoneyMap into your routine with weekly reviews.</li>' .
+        '<li style="margin-bottom:0;">Explore Baby Steps, emergency funds, and long-term goals.</li>' .
         '</ul>' .
-        '<p>We\'re thrilled to have you on board!<br />— The MyMoneyMap team</p>';
+        '<p style="margin:0;">We\'re thrilled to have you on board!<br />— The MyMoneyMap team</p>';
+
+    $html = email_wrap_html('Welcome to MyMoneyMap', $body);
 
     $text = "Hi {$name},\n\n" .
         "Your MyMoneyMap registration was successful. Start tracking your finances right away: add transactions, review budgets, and set meaningful goals.\n\n" .
@@ -108,13 +172,15 @@ function email_send_tips(array $user, ?array $tips = null): bool
     $tips = $tips && is_array($tips) ? $tips : email_default_tips();
     $name = email_user_display_name($user);
 
-    $html = '<p>Hi ' . htmlspecialchars($name) . ',</p>' .
-        '<p>Here are a few tips to help you get even more value from MyMoneyMap:</p>' .
-        '<ul>';
+    $body = '<p style="margin:0 0 16px;">Hi ' . htmlspecialchars($name) . ',</p>' .
+        '<p style="margin:0 0 16px;">Here are a few tips to help you get even more value from MyMoneyMap:</p>' .
+        '<ul style="margin:0 0 16px;padding-left:20px;">';
     foreach ($tips as $tip) {
-        $html .= '<li>' . htmlspecialchars($tip) . '</li>';
+        $body .= '<li style="margin-bottom:8px;">' . htmlspecialchars($tip) . '</li>';
     }
-    $html .= '</ul><p>Happy tracking!<br />— The MyMoneyMap team</p>';
+    $body .= '</ul><p style="margin:0;">Happy tracking!<br />— The MyMoneyMap team</p>';
+
+    $html = email_wrap_html('Tips & tricks for MyMoneyMap', $body);
 
     $text = "Hi {$name},\n\n" .
         "Here are a few tips to help you get more value from MyMoneyMap:\n" .
@@ -193,31 +259,33 @@ function email_send_period_results(PDO $pdo, array $user, DateTimeImmutable $sta
     $rangeLabel = email_period_label($start, $end);
     $currency = $summary['currency'];
 
-    $html = '<p>Hi ' . htmlspecialchars($name) . ',</p>' .
-        '<p>Here is your ' . htmlspecialchars($label) . ' summary for ' . htmlspecialchars($rangeLabel) . '.</p>';
+    $body = '<p style="margin:0 0 16px;">Hi ' . htmlspecialchars($name) . ',</p>' .
+        '<p style="margin:0 0 16px;">Here is your ' . htmlspecialchars($label) . ' summary for ' . htmlspecialchars($rangeLabel) . '.</p>';
 
     if ($summary['transaction_count'] === 0) {
-        $html .= '<p>No transactions were recorded during this period. Add new entries from your dashboard to keep your finances up to date.</p>';
+        $body .= '<p style="margin:0 0 16px;">No transactions were recorded during this period. Add new entries from your dashboard to keep your finances up to date.</p>';
     } else {
-        $html .= '<table style="border-collapse:collapse;width:100%;max-width:480px;margin:16px 0;">'
-            . '<tr><td style="padding:8px;border:1px solid #e2e8f0;">Income</td><td style="padding:8px;border:1px solid #e2e8f0;text-align:right;">'
+        $body .= '<table style="border-collapse:collapse;width:100%;max-width:480px;margin:16px 0;border-radius:16px;overflow:hidden;">'
+            . '<tr style="background:#f1f5f9;"><td style="padding:12px 16px;font-weight:600;color:#0f172a;border:1px solid #e2e8f0;">Income</td><td style="padding:12px 16px;text-align:right;color:#0f172a;border:1px solid #e2e8f0;">'
             . htmlspecialchars(email_format_amount($summary['income_total'], $currency)) . '</td></tr>'
-            . '<tr><td style="padding:8px;border:1px solid #e2e8f0;">Spending</td><td style="padding:8px;border:1px solid #e2e8f0;text-align:right;">'
+            . '<tr><td style="padding:12px 16px;font-weight:600;color:#0f172a;border:1px solid #e2e8f0;">Spending</td><td style="padding:12px 16px;text-align:right;color:#0f172a;border:1px solid #e2e8f0;">'
             . htmlspecialchars(email_format_amount($summary['spending_total'], $currency)) . '</td></tr>'
-            . '<tr><td style="padding:8px;border:1px solid #e2e8f0;">Net</td><td style="padding:8px;border:1px solid #e2e8f0;text-align:right;">'
+            . '<tr style="background:#f8fafc;"><td style="padding:12px 16px;font-weight:600;color:#0f172a;border:1px solid #e2e8f0;">Net</td><td style="padding:12px 16px;text-align:right;color:#0f172a;border:1px solid #e2e8f0;">'
             . htmlspecialchars(email_format_amount($summary['net'], $currency)) . '</td></tr>'
             . '</table>';
 
         if ($summary['top_categories']) {
-            $html .= '<p>Top spending categories:</p><ul>';
+            $body .= '<p style="margin:0 0 8px;">Top spending categories:</p><ul style="margin:0 0 16px;padding-left:20px;">';
             foreach ($summary['top_categories'] as $category => $amount) {
-                $html .= '<li>' . htmlspecialchars($category) . ' — ' . htmlspecialchars(email_format_amount($amount, $currency)) . '</li>';
+                $body .= '<li style="margin-bottom:8px;">' . htmlspecialchars($category) . ' — ' . htmlspecialchars(email_format_amount($amount, $currency)) . '</li>';
             }
-            $html .= '</ul>';
+            $body .= '</ul>';
         }
     }
 
-    $html .= '<p>Keep going — every entry moves you closer to your goals.<br />— The MyMoneyMap team</p>';
+    $body .= '<p style="margin:0;">Keep going — every entry moves you closer to your goals.<br />— The MyMoneyMap team</p>';
+
+    $html = email_wrap_html('Your ' . ucfirst($label) . ' MyMoneyMap summary', $body);
 
     $textLines = [
         "Hi {$name},",


### PR DESCRIPTION
## Summary
- introduce a reusable HTML wrapper that applies MyMoneyMap branding, logo, and dark-mode styling to outbound emails
- update verification, welcome, tips, and summary messages to use the shared layout and refreshed typography

## Testing
- php -l src/services/email_notifications.php

------
https://chatgpt.com/codex/tasks/task_e_68e29872df7c8329ad8ffd664c46f40e