### PR TITLE
Add goal category support for manual contributions

### DIFF
--- a/migrations/036_goal_category.sql
+++ b/migrations/036_goal_category.sql
@@ -1,0 +1,4 @@
+ALTER TABLE goals
+  ADD COLUMN IF NOT EXISTS category_id INT NULL REFERENCES categories(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_goals_category ON goals(category_id);

--- a/src/controllers/month.php
+++ b/src/controllers/month.php
@@ -320,6 +320,9 @@ function month_show(PDO $pdo, ?int $year = null, ?int $month = null) {
         gc.occurred_on,
         gc.note,
         g.title AS goal_title,
+        g.category_id       AS goal_category_id,
+        cg.label            AS goal_cat_label,
+        COALESCE(NULLIF(cg.color,''),'#10B981') AS goal_cat_color,
         sp.category_id      AS scheduled_category_id,
         c.label             AS scheduled_cat_label,
         COALESCE(NULLIF(c.color,''),'#10B981') AS scheduled_cat_color
@@ -327,6 +330,9 @@ function month_show(PDO $pdo, ?int $year = null, ?int $month = null) {
     JOIN goals g
       ON g.id = gc.goal_id
     AND g.user_id = ?
+    LEFT JOIN categories cg
+           ON cg.id = g.category_id
+          AND cg.user_id = g.user_id
     LEFT JOIN scheduled_payments sp
            ON sp.goal_id = gc.goal_id
           AND sp.user_id = gc.user_id
@@ -349,6 +355,11 @@ function month_show(PDO $pdo, ?int $year = null, ?int $month = null) {
       $schedCategoryId = null;
     }
 
+    $goalCategoryId = isset($gc['goal_category_id']) ? (int)$gc['goal_category_id'] : 0;
+    if ($goalCategoryId <= 0) {
+      $goalCategoryId = null;
+    }
+
     $categoryId = null;
     $catLabel = 'Goal';
     $catColor = '#10B981';
@@ -357,6 +368,10 @@ function month_show(PDO $pdo, ?int $year = null, ?int $month = null) {
       $categoryId = $schedCategoryId;
       $catLabel = $gc['scheduled_cat_label'] ?: $catLabel;
       $catColor = $gc['scheduled_cat_color'] ?: $catColor;
+    } elseif ($goalCategoryId !== null) {
+      $categoryId = $goalCategoryId;
+      $catLabel = $gc['goal_cat_label'] ?: $catLabel;
+      $catColor = $gc['goal_cat_color'] ?: $catColor;
     }
 
     $rowV = [

--- a/views/goals/index.php
+++ b/views/goals/index.php
@@ -37,9 +37,18 @@ $allGoals = $allGoals ?? array_merge($activeGoals, $archivedGoals);
         <label class="label"><?= __('Current (optional)') ?></label>
         <input name="current_amount" type="number" step="0.01" class="input" placeholder="0.00" />
       </div>
-      <div class="sm:col-span-12">
+      <div class="sm:col-span-6">
+        <label class="label"><?= __('Category') ?></label>
+        <select name="category_id" class="select">
+          <option value=""><?= __('No category') ?></option>
+          <?php foreach ($categories as $c): ?>
+            <option value="<?= (int)$c['id'] ?>"><?= htmlspecialchars($c['label']) ?></option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+      <div class="sm:col-span-6">
         <label class="label"><?= __('Status') ?></label>
-        <select name="status" class="select w-full max-w-xs">
+        <select name="status" class="select w-full">
           <option value="active"><?= __('Active') ?></option>
           <option value="paused"><?= __('Paused') ?></option>
           <option value="done"><?= __('Done') ?></option>
@@ -407,7 +416,7 @@ $allGoals = $allGoals ?? array_merge($activeGoals, $archivedGoals);
 </section>
 <?php endif; ?>
 
-<?php foreach ($allGoals as $g): $goalId=(int)$g['id']; $cur=$g['currency'] ?: 'HUF'; $goalTxList = $goalTransactions[$goalId] ?? []; $statusForArchive = strtolower((string)($g['status'] ?? '')); $isArchivedGoal = !empty($g['archived_at']) || in_array($statusForArchive, ['done','completed'], true); $goalLockedForModal = !empty($g['_is_completed']) && empty($g['archived_at']); $completedByScheduleModal = !empty($g['_completed_by_schedule']); ?>
+<?php foreach ($allGoals as $g): $goalId=(int)$g['id']; $cur=$g['currency'] ?: 'HUF'; $goalCategoryId=(int)($g['category_id'] ?? 0); $goalTxList = $goalTransactions[$goalId] ?? []; $statusForArchive = strtolower((string)($g['status'] ?? '')); $isArchivedGoal = !empty($g['archived_at']) || in_array($statusForArchive, ['done','completed'], true); $goalLockedForModal = !empty($g['_is_completed']) && empty($g['archived_at']); $completedByScheduleModal = !empty($g['_completed_by_schedule']); ?>
 <div id="goal-edit-<?= $goalId ?>" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="goal-edit-title-<?= $goalId ?>">
   <div class="modal-backdrop" data-close></div>
 
@@ -451,6 +460,16 @@ $allGoals = $allGoals ?? array_merge($activeGoals, $archivedGoals);
                 <select name="currency" class="select">
                   <?php foreach ($userCurrencies as $uc): $code=$uc['code']; ?>
                     <option value="<?= htmlspecialchars($code) ?>" <?= strtoupper($code)===strtoupper($cur)?'selected':'' ?>><?= htmlspecialchars($code) ?></option>
+                  <?php endforeach; ?>
+                </select>
+              </div>
+
+              <div class="sm:col-span-6">
+                <label class="label"><?= __('Category') ?></label>
+                <select name="category_id" class="select">
+                  <option value=""><?= __('No category') ?></option>
+                  <?php foreach ($categories as $c): $cid=(int)$c['id']; ?>
+                    <option value="<?= $cid ?>" <?= (int)($g['category_id'] ?? 0) === $cid ? 'selected' : '' ?>><?= htmlspecialchars($c['label']) ?></option>
                   <?php endforeach; ?>
                 </select>
               </div>
@@ -537,8 +556,8 @@ $allGoals = $allGoals ?? array_merge($activeGoals, $archivedGoals);
                 <label class="label"><?= __('Category') ?></label>
                 <select name="category_id" class="select">
                     <option value=""><?= __('No category') ?></option>
-                    <?php foreach ($categories as $c): ?>
-                      <option value="<?= (int)$c['id'] ?>"><?= htmlspecialchars($c['label']) ?></option>
+                    <?php foreach ($categories as $c): $cid=(int)$c['id']; ?>
+                      <option value="<?= $cid ?>" <?= $goalCategoryId === $cid ? 'selected' : '' ?>><?= htmlspecialchars($c['label']) ?></option>
                     <?php endforeach; ?>
                   </select>
                 </div>
@@ -603,8 +622,8 @@ $allGoals = $allGoals ?? array_merge($activeGoals, $archivedGoals);
                 <label class="label"><?= __('Category') ?></label>
                 <select name="category_id" class="select">
                   <option value=""><?= __('No category') ?></option>
-                  <?php foreach ($categories as $c): ?>
-                    <option value="<?= (int)$c['id'] ?>"><?= htmlspecialchars($c['label']) ?></option>
+                  <?php foreach ($categories as $c): $cid=(int)$c['id']; ?>
+                    <option value="<?= $cid ?>" <?= $goalCategoryId === $cid ? 'selected' : '' ?>><?= htmlspecialchars($c['label']) ?></option>
                   <?php endforeach; ?>
                 </select>
               </div>


### PR DESCRIPTION
## Summary
- allow setting and persisting a category on goals so manual contributions can be classified
- ensure monthly goal contribution virtual transactions fall back to the goal category when a schedule category is absent
- expose category selectors in the goal UI and default schedule creation to the goal's category

## Testing
- php -l src/controllers/goals.php
- php -l src/controllers/month.php
- php -l views/goals/index.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f60663a4832991eda9be8b4c4fc5)